### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Both parts require the following tools and libraries:
 The heaptrack data collector and the simplistic `heaptrack_print` analyzer depend on the
 following libraries:
 
-- boost 1.41 or higher: iostream, program_options
+- boost 1.41 or higher: iostreams, program_options
 - libunwind
 - elfutils: libdwarf
 


### PR DESCRIPTION
This `s` matters when specifying `--with-libraries` option on boost's bootstrap.sh.

I ran into this when I was trying to build boost-1.41.0 required by heaptrack on Ubuntu 16.04.