### PR TITLE
Add missing include directory.

### DIFF
--- a/tests/benchmarks/CMakeLists.txt
+++ b/tests/benchmarks/CMakeLists.txt
@@ -1,4 +1,6 @@
 include_directories(../..)
+include_directories(${Boost_INCLUDE_DIRS})
+
 
 include (CheckCXXSourceCompiles)
 check_cxx_source_compiles(


### PR DESCRIPTION
- Boost headers are at $BOOST_ROOT which might not be on the default
  include path.