### PR TITLE
Fix crash if an ELF module has no symbol table

### DIFF
--- a/3rdparty/libbacktrace/elf.c
+++ b/3rdparty/libbacktrace/elf.c
@@ -516,7 +516,7 @@ elf_nodebug (struct backtrace_state *state ATTRIBUTE_UNUSED,
 /* A dummy callback function used when we can't find a symbol
    table.  */
 
-static void
+void
 elf_nosyms (struct backtrace_state *state ATTRIBUTE_UNUSED,
 	    uintptr_t addr ATTRIBUTE_UNUSED,
 	    backtrace_syminfo_callback callback ATTRIBUTE_UNUSED,

--- a/3rdparty/libbacktrace/internal.h
+++ b/3rdparty/libbacktrace/internal.h
@@ -315,6 +315,11 @@ extern void elf_syminfo (struct backtrace_state *state, uintptr_t addr,
 			 backtrace_syminfo_callback callback,
 			 backtrace_error_callback error_callback ATTRIBUTE_UNUSED,
 			 void *data);
+extern void elf_nosyms (struct backtrace_state *state ATTRIBUTE_UNUSED,
+			uintptr_t addr ATTRIBUTE_UNUSED,
+			backtrace_syminfo_callback callback ATTRIBUTE_UNUSED,
+			backtrace_error_callback error_callback, void *data);
+
 //END HEAPTRACK
 
 #ifdef __cplusplus

--- a/src/interpret/heaptrack_interpret.cpp
+++ b/src/interpret/heaptrack_interpret.cpp
@@ -344,6 +344,8 @@ struct AccumulatedTraceData
                                    &foundDwarf, false, false);
                 if (ret && foundSym) {
                     state->syminfo_fn = &elf_syminfo;
+                } else {
+                    state->syminfo_fn = &elf_nosyms;
                 }
             }
         }


### PR DESCRIPTION
Set libbacktrace's dummy callback function to avoid it calling a null pointer.