### PR TITLE
Serialize data back to heaptrack in another thread + cache searches on trace tree

### DIFF
--- a/src/track/bufferedstream.h
+++ b/src/track/bufferedstream.h
@@ -1,0 +1,224 @@
+#ifndef HEAPTRACK_BUFFEREDSTREAM
+#define HEAPTRACK_BUFFEREDSTREAM
+
+#include <mutex>
+#include <condition_variable>
+#include <thread>
+
+class BufferedStream
+{
+    static constexpr int MaxMsgs = 1000000;
+
+    enum class MsgType
+    {
+        Empty,
+        Alloc,
+        Dealloc,
+    };
+
+    struct AllocMsg {
+        std::size_t size;
+        std::uint32_t index;
+        void* ptr;
+    };
+
+    struct DeallocMsg {
+        void* ptr;
+    };
+
+    struct Msg
+    {
+        Msg() = default;
+        Msg(const AllocMsg& msg)
+            : m_type(MsgType::Alloc)
+        {
+            m_data.allocMsg = msg;
+        }
+
+        Msg(const DeallocMsg& msg)
+            : m_type(MsgType::Dealloc)
+        {
+            m_data.deallocMsg = msg;
+        }
+
+        MsgType m_type = MsgType::Empty;
+
+        union
+        {
+            AllocMsg allocMsg;
+            DeallocMsg deallocMsg;
+
+        } m_data;
+    };
+
+  public:
+    BufferedStream(FILE* f)
+        : m_stream(f)
+    {
+        m_msgQueue            = new Msg[MaxMsgs];
+        m_serializationBuffer = new Msg[MaxMsgs];
+        initSerializationThread();
+    }
+
+    ~BufferedStream() {
+        disableBuffering();
+        delete[] m_msgQueue;
+        delete[] m_serializationBuffer;
+    }
+
+    operator bool() const { return bool(m_stream); }
+    bool operator!() const { return !bool(m_stream); }
+
+    bool sendTimestamp(std::size_t timeCnt) {
+        return fprintf("c %" PRIx64 "\n", timeCnt) < 0;
+    }
+
+    bool sendRSS(std::size_t byteCnt) {
+        return fprintf("R %zx\n", byteCnt) < 0;
+    }
+
+    bool sendAllocation(std::size_t size, std::uint32_t index, void* ptr) {
+        return m_buffering ? (enqueueAllocation(size, index, ptr) < 0)
+                           : (fprintf("+ %zx %x %" PRIxPTR "\n", size, index, reinterpret_cast<uintptr_t>(ptr)) < 0);
+    }
+
+    bool sendDeallocation(void* ptr) {
+        return m_buffering ? (enqueueDeallocation(ptr) < 0)
+                           : (fprintf("- %" PRIxPTR "\n", reinterpret_cast<uintptr_t>(ptr)) < 0);
+    }
+
+    template<class...T>
+    int fprintf(const char* format, T&&... args) {
+        flush();
+        return ::fprintf(m_stream, format, std::forward<T>(args)...);
+    }
+
+    int fputc(int c) {
+        flush();
+        return ::fputc(c, m_stream);
+    }
+
+    int fputs(const char* str) {
+        flush();
+        return ::fputs(str, m_stream);
+    }
+
+    void clear() {
+        flush();
+        m_stream = nullptr;
+    }
+
+    void fclose() {
+        flush();
+        ::fclose(m_stream);
+    }
+
+    // Buffering stuff
+    int enqueueAllocation(std::size_t size, std::uint32_t index, void* ptr) {
+        bool notify = false;
+        {
+            std::unique_lock<std::mutex> lock(m_msgQueueMutex);
+
+            while (m_msgIdx == MaxMsgs)
+                m_msgQueueCv.wait(lock);
+
+            m_msgQueue[m_msgIdx++] = Msg(AllocMsg{size, index, ptr});
+
+            notify = m_msgIdx == MaxMsgs/2;
+        }
+        if (notify)
+            m_msgQueueCv.notify_one();
+        return 1;
+    }
+
+    int enqueueDeallocation(void* ptr) {
+        bool notify = false;
+        {
+            std::unique_lock<std::mutex> lock(m_msgQueueMutex);
+
+            while (m_msgIdx == MaxMsgs)
+                m_msgQueueCv.wait(lock);
+
+            m_msgQueue[m_msgIdx++] = Msg(DeallocMsg{ptr});
+            notify = m_msgIdx == MaxMsgs/2;
+        }
+        if (notify)
+            m_msgQueueCv.notify_one();
+        return 1;
+    }
+
+    void flush() {
+        std::unique_lock<std::mutex> lock1(m_msgQueueMutex);
+        std::unique_lock<std::mutex> lock2(m_streamMutex);
+
+        writeMsgs(m_stream, m_serializationBuffer, m_serializationMsgIdx);
+        m_serializationMsgIdx = 0;
+
+        writeMsgs(m_stream, m_msgQueue, m_msgIdx);
+        m_msgIdx = 0;
+    }
+
+    void disableBuffering() {
+        flush();
+        m_buffering = false;
+    }
+
+    void initSerializationThread() {
+        m_serializationThread = std::thread([this] () {
+            for (;;) {
+                {
+                    std::unique_lock<std::mutex> lock(m_msgQueueMutex);
+
+                    while (m_msgIdx == 0)
+                        m_msgQueueCv.wait(lock);
+
+                    std::swap(m_serializationBuffer, m_msgQueue);
+                    std::swap(m_serializationMsgIdx, m_msgIdx);
+                }
+                m_msgQueueCv.notify_one();
+
+                std::unique_lock<std::mutex> lock(m_streamMutex);
+                writeMsgs(m_stream, m_serializationBuffer, m_serializationMsgIdx);
+                m_serializationMsgIdx = 0;
+            }
+        });
+    }
+
+    static void writeMsgs(FILE* stream, Msg* msgs, int numMsgs) {
+        for (int i = 0; i < numMsgs; ++i) {
+            auto& msg = msgs[i];
+            switch (msg.m_type) {
+                case MsgType::Alloc: {
+                    ::fprintf(stream, "+ %zx %x %" PRIxPTR "\n",
+                              msg.m_data.allocMsg.size,
+                              msg.m_data.allocMsg.index,
+                              reinterpret_cast<uintptr_t>(msg.m_data.allocMsg.ptr));
+                    break;
+                }
+                case MsgType::Dealloc: {
+                    ::fprintf(stream, "- %" PRIxPTR "\n", reinterpret_cast<uintptr_t>(msg.m_data.deallocMsg.ptr));
+                    break;
+                }
+                case MsgType::Empty: {
+                    break;
+                }
+            }
+        }
+    }
+
+    FILE* m_stream;
+    bool  m_buffering = true;
+
+    std::mutex              m_msgQueueMutex;
+    std::condition_variable m_msgQueueCv;
+    Msg* m_msgQueue;
+    int  m_msgIdx = 0;
+
+    std::mutex              m_streamMutex;
+    std::thread             m_serializationThread;
+    Msg*                    m_serializationBuffer;
+    int                     m_serializationMsgIdx = 0;
+
+};
+
+#endif


### PR DESCRIPTION
**Do not merge!**

I've been using heaptrack every now and then, and while it's much faster than valgrind (which simply gives up), it takes over a day to run it on my case. So I spent some time to optimize it.

**If improvements like this have been discussed and ruled out, please go ahead and close it. I imagine there may be subtle details which could invalidate this proposal**

This pull request contains **experimental** changes to improve the performance of the allocation data serialization back to heaptrack interpreter. It's just a proof of concept, really.

There are two main changes here:
1. Instead of calling fprintf on every allocation/deallocation, just add the data to a queue. A thread is created to consume data on this queue and call fprintf.
- I'm a bit concerned fprintf may call malloc/free, which I suppose could cause deadlock. It hasn't deadlocked in any of the runs though, so maybe I'm missing something.
2. Create a cache of "last search" on each node of the trace tree. This helps speeding up consecutive allocations on the same (or similar) stack.

I used the following testcase for performance validation:
[main.txt](https://github.com/KDE/heaptrack/files/1913547/main.txt)

This testcase is tailored for the two optimizations, so I wouldn't expect the same results on real scenarios. I did not test this on my testcase yet (don't have access to the company network on weekend :) )

This does a bunch of string manipulations and sleep every now and then. The sleep is to simulate time not doing allocations on real applications.

- Time without heaptrack: 54 seconds
- Time with heaptrack: 100 seconds
- Time with heaptrack + this patch:  74 seconds

I will validate this patch on my 1 day testcase during this week, and if it gives significant improvement, I can work on separate it on two or three changesets, fix bugs, improve error handling and so on...

I created a pull request to kick off a discussion (if it hasn't been discussed yet), and gather feedback.






