### PR TITLE
Build GUI for non-Linux systems

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -2,8 +2,10 @@ if (ECM_FOUND)
     include(ECMEnableSanitizers)
 endif()
 
-add_subdirectory(libbacktrace)
+if(HEAPTRACK_BUILD_TRACK)
+    add_subdirectory(libbacktrace)
+endif()
 
 if (ZSTD_FOUND)
-add_subdirectory(boost-zstd)
+    add_subdirectory(boost-zstd)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,30 +23,44 @@ set(HEAPTRACK_FILE_FORMAT_VERSION 2)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 include(FeatureSummary)
-find_package(Libunwind REQUIRED)
-find_package(Boost 1.41.0 COMPONENTS system filesystem) # option first
-find_package(Boost 1.41.0 REQUIRED COMPONENTS iostreams program_options) # then required
+find_package(Boost 1.41.0 COMPONENTS system filesystem iostreams)
 find_package(Threads REQUIRED)
 find_package(ZLIB REQUIRED)
-find_package(Zstd)
+
+if (${BOOST_iostreams_FOUND})
+    find_package(Zstd)
+endif()
 set_package_properties(Zstd PROPERTIES TYPE RECOMMENDED PURPOSE "Zstandard offers better (de)compression performance compared with gzip/zlib, making heaptrack faster and datafiles smaller.")
+
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+    set(HEAPTRACK_BUILD_TRACK_DEFAULT ON)
+else()
+    set(HEAPTRACK_BUILD_TRACK_DEFAULT OFF)
+endif()
+
+option(
+  HEAPTRACK_BUILD_TRACK
+  "Disable this option to skip building the tracker part for heaptrack, e.g. to only build the GUI."
+  ${HEAPTRACK_BUILD_TRACK_DEFAULT}
+)
+
+if (CMAKE_CROSSCOMPILING)
+    set(HEAPTRACK_BUILD_ANALYZE_DEFAULT OFF)
+else()
+    set(HEAPTRACK_BUILD_ANALYZE_DEFAULT ON)
+endif()
+
+option(
+  HEAPTRACK_BUILD_PRINT
+  "Disable this option to skip building heaptrack_print, e.g. when you're cross-compiling."
+  ${HEAPTRACK_BUILD_ANALYZE_DEFAULT}
+)
 
 option(
   HEAPTRACK_BUILD_GUI
   "Disable this option to skip building the Qt5 / KF5 based GUI for heaptrack."
-  On
+  ${HEAPTRACK_BUILD_ANALYZE_DEFAULT}
 )
-
-if(HEAPTRACK_BUILD_GUI)
-    find_package(Qt5 5.2.0 NO_MODULE OPTIONAL_COMPONENTS Widgets)
-    find_package(ECM 1.0.0 NO_MODULE)
-    if(Qt5_FOUND AND ECM_FOUND)
-        set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR})
-            find_package(KF5 COMPONENTS CoreAddons I18n ItemModels ThreadWeaver ConfigWidgets KIO)
-            find_package(KChart "2.6.0")
-            set_package_properties(KChart PROPERTIES TYPE RECOMMENDED PURPOSE "Required for the heaptrack_gui executable. Get it from the kdiagram module.")
-    endif()
-endif()
 
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
@@ -64,17 +78,6 @@ if (NOT HAVE_CXX11_SUPPORT)
     message(FATAL_ERROR "Your compiler is too old and does not support the required C++11 features.")
 endif()
 
-check_cxx_source_compiles(
-    "#include <stdio_ext.h>
-    #include <fcntl.h>
-    #include <dlfcn.h>
-    #include <link.h>
-    int main() { return 0; }"
-    HAVE_LINUX_HEADERS)
-
-if (NOT HAVE_LINUX_HEADERS)
-    message(FATAL_ERROR "You are missing some Linux headers required to compile heaptrack.")
-endif()
 
 # cfree() does not exist in glibc 2.26+.
 # See: https://bugs.kde.org/show_bug.cgi?id=383889
@@ -95,6 +98,22 @@ file(RELATIVE_PATH LIB_REL_PATH
     "${CMAKE_INSTALL_PREFIX}/${LIB_INSTALL_DIR}/heaptrack")
 
 set(ECM_ENABLE_SANITIZERS "" CACHE STRING "semicolon-separated list of sanitizers to enable for code that is not injected into client applications")
+
+if (HEAPTRACK_BUILD_TRACK)
+    find_package(Libunwind REQUIRED)
+
+    check_cxx_source_compiles(
+        "#include <stdio_ext.h>
+        #include <fcntl.h>
+        #include <dlfcn.h>
+        #include <link.h>
+        int main() { return 0; }"
+        HAVE_LINUX_HEADERS)
+
+    if (NOT HAVE_LINUX_HEADERS)
+        message(FATAL_ERROR "You are missing some Linux headers required to compile heaptrack.")
+    endif()
+endif()
 
 add_subdirectory(3rdparty)
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -107,6 +107,36 @@ of the CMake command, as it will tell you about missing dependencies!
     cmake -DCMAKE_BUILD_TYPE=Release .. # look for messages about missing dependencies!
     make -j$(nproc)
 
+#### Compile `heaptrack_gui` on macOS using homebrew
+
+`heaptrack_print` and `heaptrack_gui` can be built on platforms other than Linux, using the dependencies mentioned above.
+On macOS the dependencies can be installed easily using [homebrew](http://brew.sh) and the [KDE homebrew tap](https://github.com/KDE-mac/homebrew-kde).
+
+    # prepare tap
+    brew tap kde-mac/kde
+    "$(brew --repo)/Library/Taps/kde-mac/homebrew-kde/tools/all-fixes.sh"
+    
+    # install dependencies
+    brew install kde-mac/kde/kf5-extra-cmake-modules kde-mac/kde/kf5-kcoreaddons kde-mac/kde/kf5-ki18n \
+                 kde-mac/kde/kf5-kitemmodels kde-mac/kde/kf5-threadweaver kde-mac/kde/kf5-kconfigwidgets \
+                 kde-mac/kde/kf5-kio kde-mac/kde/kf5-kdiagram \
+                 boost zstd gettext
+    
+    # run manual steps as printed by brew
+    ln -sfv "$(brew --prefix)/share/kf5" "$HOME/Library/Application Support"
+    ln -sfv "$(brew --prefix)/share/knotifications5" "$HOME/Library/Application Support"
+    ln -sfv "$(brew --prefix)/share/kservices5" "$HOME/Library/Application Support"
+    ln -sfv "$(brew --prefix)/share/kservicetypes5" "$HOME/Library/Application Support"
+
+To compile make sure to use Qt from homebrew and to have gettext in the path:
+
+    cd heaptrack # i.e. the source folder
+    mkdir build
+    cd build
+    CMAKE_PREFIX_PATH=/usr/local/opt/qt PATH=$PATH:/usr/local/opt/gettext/bin cmake ..
+    cmake -DCMAKE_BUILD_TYPE=Release .. # look for messages about missing dependencies!
+    make heaptrack_gui heaptrack_print
+
 ## Interpreting the heap profile
 
 Heaptrack generates data files that are impossible to analyze for a human. Instead, you need

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ On macOS the dependencies can be installed easily using [homebrew](http://brew.s
     # install dependencies
     brew install kde-mac/kde/kf5-extra-cmake-modules kde-mac/kde/kf5-kcoreaddons kde-mac/kde/kf5-ki18n \
                  kde-mac/kde/kf5-kitemmodels kde-mac/kde/kf5-threadweaver kde-mac/kde/kf5-kconfigwidgets \
-                 kde-mac/kde/kf5-kio kde-mac/kde/kf5-kdiagram \
+                 kde-mac/kde/kf5-kio kde-mac/kde/kdiagram \
                  boost zstd gettext
     
     # run manual steps as printed by brew

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,12 @@ include_directories(
 )
 
 add_subdirectory(util)
-add_subdirectory(track)
-add_subdirectory(interpret)
-add_subdirectory(analyze)
+
+if (HEAPTRACK_BUILD_TRACK)
+    add_subdirectory(track)
+    add_subdirectory(interpret)
+endif()
+
+if (HEAPTRACK_BUILD_PRINT OR HEAPTRACK_BUILD_GUI)
+    add_subdirectory(analyze)
+endif()

--- a/src/analyze/CMakeLists.txt
+++ b/src/analyze/CMakeLists.txt
@@ -2,6 +2,8 @@ if (ECM_FOUND)
     include(ECMEnableSanitizers)
 endif()
 
+find_package(Boost 1.41.0 REQUIRED COMPONENTS iostreams program_options)
+
 configure_file(analyze_config.h.cmake ${CMAKE_CURRENT_BINARY_DIR}/analyze_config.h)
 
 include_directories(
@@ -21,12 +23,23 @@ target_link_libraries(sharedprint LINK_PUBLIC
 )
 
 if (ZSTD_FOUND)
-target_link_libraries(sharedprint LINK_PUBLIC
-    boost-zstd
-)
+    target_link_libraries(sharedprint LINK_PUBLIC
+        boost-zstd
+    )
 endif()
 
 add_subdirectory(print)
+
+if(HEAPTRACK_BUILD_GUI)
+    find_package(Qt5 5.2.0 NO_MODULE OPTIONAL_COMPONENTS Widgets)
+    find_package(ECM 1.0.0 NO_MODULE)
+    if(Qt5_FOUND AND ECM_FOUND)
+        set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR})
+            find_package(KF5 COMPONENTS CoreAddons I18n ItemModels ThreadWeaver ConfigWidgets KIO)
+            find_package(KChart "2.6.0")
+            set_package_properties(KChart PROPERTIES TYPE RECOMMENDED PURPOSE "Required for the heaptrack_gui executable. Get it from the kdiagram module.")
+    endif()
+endif()
 
 if (KF5_FOUND)
     add_subdirectory(gui)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
-add_subdirectory(manual)
-add_subdirectory(auto)
-add_subdirectory(benchmarks)
+if (HEAPTRACK_BUILD_TRACK AND BUILD_TESTING)
+    add_subdirectory(manual)
+    add_subdirectory(auto)
+    add_subdirectory(benchmarks)
+endif()


### PR DESCRIPTION
Change the cmake files so that the GUI and print part of heaptrack can be built on a non-Linux system, e.g. on macOS. On non-Linux systems everything but heaptrack_print and heaptrack_gui is skipped, also the tests.
Add a short description for macOS using homebrew.