### PR TITLE
Added --output option

### DIFF
--- a/src/track/heaptrack.sh.cmake
+++ b/src/track/heaptrack.sh.cmake
@@ -96,9 +96,13 @@ while true; do
             exit 0
             ;;
         "-o" | "--output-file")
-            output=$2
-            if [ -z "$output" ]; then
+            if [ -z "$2" ]; then
                 echo "Missing output argument."
+                exit 1
+            fi
+            output=$(readlink -f $2)
+            if [ -d "$output" ]; then
+                echo "Please specify a file-name or a full path-name for output."
                 exit 1
             fi
             shift 2

--- a/src/track/heaptrack.sh.cmake
+++ b/src/track/heaptrack.sh.cmake
@@ -52,6 +52,7 @@ usage() {
     echo "                 to the debuggee."
     echo "  -h, --help     Show this help message and exit."
     echo "  -v, --version  Displays version information."
+    echo "  -o, --output   Specifies the data-file for the captured data."
     echo
     echo "Alternatively, to analyze a recorded heaptrack data file:"
     echo "  -a, --analyze FILE    Open the heaptrack data file in heaptrack_gui, if available,"
@@ -93,6 +94,14 @@ while true; do
         "-h" | "--help")
             usage
             exit 0
+            ;;
+        "-o" | "--output-file")
+            output=$2
+            if [ -z "$output" ]; then
+                echo "Missing output argument."
+                exit 1
+            fi
+            shift 2
             ;;
         "-p" | "--pid")
             if [ -z "$(which gdb 2> /dev/null)" ]; then
@@ -148,7 +157,9 @@ while true; do
 done
 
 # put output into current pwd
-output=$(pwd)/heaptrack.$(basename "$client").$$
+if [ -z "$output" ]; then
+    output=$(pwd)/heaptrack.$(basename "$client").$$
+fi
 
 # find preload library and interpreter executable using relative paths
 LIB_REL_PATH="@LIB_REL_PATH@"


### PR DESCRIPTION
I added an option to specify the file-name for the data-file.

I need that in order to use heaptrack in docker/kubernetes deployments, where the pid is always the same, and the output directory is shared among containers. 