### PR TITLE
Checks if leaked memory resident in RAM.

### DIFF
--- a/src/analyze/allocationdata.h
+++ b/src/analyze/allocationdata.h
@@ -31,6 +31,8 @@ struct AllocationData
     int64_t leaked = 0;
     // largest amount of bytes allocated
     int64_t peak = 0;
+    // amount of in RAM bytes leaked(HW RAM used)
+    int64_t inRam = 0;
 
     void clearCost()
     {
@@ -55,6 +57,7 @@ inline AllocationData& operator+=(AllocationData& lhs, const AllocationData& rhs
     lhs.temporary += rhs.temporary;
     lhs.peak += rhs.peak;
     lhs.leaked += rhs.leaked;
+    lhs.inRam += rhs.inRam;
     return lhs;
 }
 
@@ -64,6 +67,7 @@ inline AllocationData& operator-=(AllocationData& lhs, const AllocationData& rhs
     lhs.temporary -= rhs.temporary;
     lhs.peak -= rhs.peak;
     lhs.leaked -= rhs.leaked;
+    lhs.inRam -= rhs.inRam;
     return lhs;
 }
 


### PR DESCRIPTION
Previously all virtual memory that is not released is considered as a leak.
This is a problem in most of the cases but not all.
Sometimes we would like to see only physical memory (RAM) which leaks. E.g.:
int* a = new int[1024*1024*1024];
int* b = new int[1024];
for(size_t i = 0; i < 1024; ++i)
    b[1024] = 0xdeadbeef;
"b" is more worrying than "a" since "a" does not leak RAM (at least on Linux by defaul).
"b" - requires one or more pages of RAM. When "a" does not use RAM at all (https://marek.vavrusa.com/memory/).
If you care more about RAM than virtual memory you should take a look.

The change introduce category "In RAM" which shows memory that leaks and is present in RAM.