### PR TITLE
Porting libheaptrack_preload to Android part.1

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -2,7 +2,7 @@ if (ECM_FOUND)
     include(ECMEnableSanitizers)
 endif()
 
-if(HEAPTRACK_BUILD_TRACK)
+if (HEAPTRACK_BUILD_BACKTRACE)
     add_subdirectory(libbacktrace)
 endif()
 

--- a/3rdparty/libbacktrace/CMakeLists.txt
+++ b/3rdparty/libbacktrace/CMakeLists.txt
@@ -170,7 +170,6 @@ include_directories (BEFORE
 )
 include_directories (
     auxincl
-    ${LIBUNWIND_INCLUDE_DIR}
 )
 
 add_library (backtrace STATIC
@@ -185,8 +184,6 @@ add_library (backtrace STATIC
     state.c
     sort.c
 )
-
-target_link_libraries(backtrace ${LIBUNWIND_LIBRARY})
 
 set_target_properties (backtrace PROPERTIES
     COMPILE_FLAGS "${CMAKE_SHARED_LIBRARY_C_FLAGS}"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,12 @@ option(
   ${HEAPTRACK_BUILD_ANALYZE_DEFAULT}
 )
 
+option(
+  HEAPTRACK_USE_LIBUNWIND
+  "Define preferred unwind functionality - Libunwind as ON and unwind_tables as OFF."
+  ON
+)
+
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
 if (NOT MSVC)
@@ -102,7 +108,9 @@ file(RELATIVE_PATH LIB_REL_PATH
 set(ECM_ENABLE_SANITIZERS "" CACHE STRING "semicolon-separated list of sanitizers to enable for code that is not injected into client applications")
 
 if (HEAPTRACK_BUILD_TRACK)
-    find_package(Libunwind REQUIRED)
+    if (HEAPTRACK_USE_LIBUNWIND)
+        find_package(Libunwind REQUIRED)
+    endif()
 
     check_cxx_source_compiles(
         "#include <stdio_ext.h>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,10 @@ set_package_properties(Zstd PROPERTIES TYPE RECOMMENDED PURPOSE "Zstandard offer
 
 if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(HEAPTRACK_BUILD_TRACK_DEFAULT ON)
+    set(HEAPTRACK_BUILD_INTERPRET_DEFAULT ON)
 else()
     set(HEAPTRACK_BUILD_TRACK_DEFAULT OFF)
+    set(HEAPTRACK_BUILD_INTERPRET_DEFAULT OFF)
 endif()
 
 option(
@@ -43,6 +45,22 @@ option(
   "Disable this option to skip building the tracker part for heaptrack, e.g. to only build the GUI."
   ${HEAPTRACK_BUILD_TRACK_DEFAULT}
 )
+
+option(
+  HEAPTRACK_BUILD_BACKTRACE
+  "Enable this option to build libbacktrace. It will be enabled implicitly if HEAPTRACK_BUILD_INTERPRET is enabled."
+  OFF
+)
+
+option(
+  HEAPTRACK_BUILD_INTERPRET
+  "Disable this option to skip building the interpret part for heaptrack."
+  ${HEAPTRACK_BUILD_INTERPRET_DEFAULT}
+)
+
+if (HEAPTRACK_BUILD_INTERPRET)
+    set(HEAPTRACK_BUILD_BACKTRACE ON)
+endif()
 
 if (CMAKE_CROSSCOMPILING)
     set(HEAPTRACK_BUILD_ANALYZE_DEFAULT OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ endif()
 # See: https://bugs.kde.org/show_bug.cgi?id=383889
 include(CheckSymbolExists)
 check_symbol_exists(cfree malloc.h HAVE_CFREE)
+check_symbol_exists(valloc stdlib.h HAVE_VALLOC)
 
 set(BIN_INSTALL_DIR "bin")
 set(LIB_SUFFIX "" CACHE STRING "Define suffix of directory name (32/64)")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,9 @@ add_subdirectory(util)
 
 if (HEAPTRACK_BUILD_TRACK)
     add_subdirectory(track)
+endif()
+
+if (HEAPTRACK_BUILD_INTERPRET)
     add_subdirectory(interpret)
 endif()
 

--- a/src/interpret/CMakeLists.txt
+++ b/src/interpret/CMakeLists.txt
@@ -5,7 +5,6 @@ endif()
 include_directories(
     ${Boost_INCLUDE_DIRS}
     ${PROJECT_SOURCE_DIR}/3rdparty/
-    ${ZLIB_INCLUDE_DIRS}
 )
 
 add_executable(heaptrack_interpret

--- a/src/track/CMakeLists.txt
+++ b/src/track/CMakeLists.txt
@@ -1,6 +1,5 @@
 include_directories(
     ${Boost_INCLUDE_DIRS}
-    ${LIBUNWIND_INCLUDE_DIR}
 )
 
 # heaptrack: bash script to inject/preload
@@ -12,6 +11,17 @@ install(PROGRAMS ${PROJECT_BINARY_DIR}/${BIN_INSTALL_DIR}/heaptrack
     DESTINATION ${BIN_INSTALL_DIR}
 )
 
+if (HEAPTRACK_USE_LIBUNWIND)
+    include_directories(${LIBUNWIND_INCLUDE_DIR})
+
+    add_library(heaptrack_unwind STATIC trace_libunwind.cpp)
+    target_link_libraries(heaptrack_unwind LINK_PRIVATE ${LIBUNWIND_LIBRARY})
+else()
+    add_library(heaptrack_unwind STATIC trace_unwind_tables.cpp)
+endif()
+
+set_property(TARGET heaptrack_unwind PROPERTY POSITION_INDEPENDENT_CODE ON)
+
 # heaptrack_preload: track a newly started process
 add_library(heaptrack_preload MODULE
     heaptrack_preload.cpp
@@ -21,7 +31,7 @@ add_library(heaptrack_preload MODULE
 target_link_libraries(heaptrack_preload LINK_PRIVATE
     ${CMAKE_DL_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
-    ${LIBUNWIND_LIBRARY}
+    heaptrack_unwind
     rt
 )
 
@@ -44,7 +54,7 @@ add_library(heaptrack_inject MODULE
 target_link_libraries(heaptrack_inject LINK_PRIVATE
     ${CMAKE_DL_LIBS}
     ${CMAKE_THREAD_LIBS_INIT}
-    ${LIBUNWIND_LIBRARY}
+    heaptrack_unwind
     rt
 )
 

--- a/src/track/heaptrack_inject.cpp
+++ b/src/track/heaptrack_inject.cpp
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <cstring>
 
+#include <dlfcn.h>
 #include <errno.h>
 #include <link.h>
 #include <malloc.h>

--- a/src/track/heaptrack_preload.cpp
+++ b/src/track/heaptrack_preload.cpp
@@ -83,7 +83,9 @@ HOOK(cfree);
 #endif
 HOOK(realloc);
 HOOK(posix_memalign);
+#if HAVE_VALLOC
 HOOK(valloc);
+#endif
 #if HAVE_ALIGNED_ALLOC
 HOOK(aligned_alloc);
 #endif
@@ -153,7 +155,9 @@ void init()
 #endif
                        hooks::realloc.init();
                        hooks::posix_memalign.init();
+#if HAVE_VALLOC
                        hooks::valloc.init();
+#endif
 #if HAVE_ALIGNED_ALLOC
                        hooks::aligned_alloc.init();
 #endif
@@ -280,6 +284,7 @@ void* aligned_alloc(size_t alignment, size_t size) noexcept
 }
 #endif
 
+#if HAVE_VALLOC
 void* valloc(size_t size) noexcept
 {
     if (!hooks::valloc) {
@@ -294,6 +299,7 @@ void* valloc(size_t size) noexcept
 
     return ret;
 }
+#endif
 
 void* dlopen(const char* filename, int flag) noexcept
 {

--- a/src/track/libheaptrack.h
+++ b/src/track/libheaptrack.h
@@ -33,6 +33,10 @@ void heaptrack_init(const char* outputFileName, heaptrack_callback_t initCallbac
 
 void heaptrack_stop();
 
+void heaptrack_pause();
+
+void heaptrack_resume();
+
 void heaptrack_malloc(void* ptr, size_t size);
 
 void heaptrack_free(void* ptr);

--- a/src/track/trace.h
+++ b/src/track/trace.h
@@ -19,13 +19,8 @@
 #ifndef TRACE_H
 #define TRACE_H
 
-#include <cstring>
-
-#define UNW_LOCAL_ONLY
-#include <libunwind.h>
-
 /**
- * @brief A libunwind based backtrace.
+ * @brief Backtrace interface.
  */
 struct Trace
 {
@@ -58,8 +53,8 @@ struct Trace
 
     bool fill(int skip)
     {
-        int size = unw_backtrace(m_data, MAX_SIZE);
-        // filter bogus frames at the end, which sometimes get returned by libunwind
+        int size = unwind(m_data);
+        // filter bogus frames at the end, which sometimes get returned by tracer backend
         // cf.: https://bugs.kde.org/show_bug.cgi?id=379082
         while (size > 0 && !m_data[size - 1]) {
             --size;
@@ -69,6 +64,13 @@ struct Trace
         return m_size > 0;
     }
 
+    static void setup();
+
+    static void print();
+
+private:
+    static int unwind(void** data);
+    
 private:
     int m_size = 0;
     int m_skip = 0;

--- a/src/track/trace_libunwind.cpp
+++ b/src/track/trace_libunwind.cpp
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2014-2019 Milian Wolff <mail@milianw.de>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * @brief A libunwind based backtrace.
+ */
+
+#include "trace.h"
+
+#include "util/libunwind_config.h"
+
+#define UNW_LOCAL_ONLY
+#include <libunwind.h>
+
+#include <stdio.h>
+
+void Trace::print()
+{
+#if LIBUNWIND_HAS_UNW_GETCONTEXT && LIBUNWIND_HAS_UNW_INIT_LOCAL
+    unw_context_t context;
+    unw_getcontext(&context);
+
+    unw_cursor_t cursor;
+    unw_init_local(&cursor, &context);
+
+    int frameNr = 0;
+    while (unw_step(&cursor)) {
+        ++frameNr;
+        unw_word_t ip = 0;
+        unw_get_reg(&cursor, UNW_REG_IP, &ip);
+
+        unw_word_t sp = 0;
+        unw_get_reg(&cursor, UNW_REG_SP, &sp);
+
+        char symbol[256] = {"<unknown>"};
+        unw_word_t offset = 0;
+        unw_get_proc_name(&cursor, symbol, sizeof(symbol), &offset);
+
+        fprintf(stderr, "#%-2d 0x%016" PRIxPTR " sp=0x%016" PRIxPTR " %s + 0x%" PRIxPTR "\n", frameNr,
+                static_cast<uintptr_t>(ip), static_cast<uintptr_t>(sp), symbol, static_cast<uintptr_t>(offset));
+    }
+#endif
+}
+
+void Trace::setup()
+{
+    // configure libunwind for better speed
+    if (unw_set_caching_policy(unw_local_addr_space, UNW_CACHE_PER_THREAD)) {
+        fprintf(stderr, "WARNING: Failed to enable per-thread libunwind caching.\n");
+    }
+#if LIBUNWIND_HAS_UNW_SET_CACHE_SIZE
+    if (unw_set_cache_size(unw_local_addr_space, 1024, 0)) {
+        fprintf(stderr, "WARNING: Failed to set libunwind cache size.\n");
+    }
+#endif
+}
+
+int Trace::unwind(void** data)
+{
+    return unw_backtrace(data, MAX_SIZE);
+}

--- a/src/track/trace_unwind_tables.cpp
+++ b/src/track/trace_unwind_tables.cpp
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 Volodymyr Nikolaichuk <nikolaychuk.volodymyr@gmail.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+/**
+ * @brief A unwind-tables based backtrace.
+ */
+
+#include "trace.h"
+
+#include <unwind.h>
+#include <stdio.h>
+
+namespace {
+
+struct backtrace
+{
+    void** data = nullptr;
+    int ctr = 0;
+    int max_size = 0;
+};
+
+_Unwind_Reason_Code unwind_backtrace_callback(struct _Unwind_Context* context, void* arg)
+{
+    backtrace* trace = static_cast<backtrace*>(arg);
+
+    uintptr_t pc = _Unwind_GetIP(context);
+    if (pc && trace->ctr < trace->max_size - 1) {
+        trace->data[trace->ctr++] = (void*)(pc);
+    }
+
+    return _URC_NO_REASON;
+}
+
+}
+
+void Trace::setup()
+{
+}
+
+void Trace::print()
+{
+    Trace trace;
+    trace.fill(1);
+    for (auto ip : trace) {
+        fprintf(stderr, "%p\n", ip);
+    }
+}
+
+int Trace::unwind(void** data)
+{
+    backtrace trace;
+    trace.data = data;
+    trace.max_size = MAX_SIZE;
+
+    _Unwind_Backtrace(unwind_backtrace_callback, &trace);
+    return trace.ctr;
+}

--- a/src/util/config.h.cmake
+++ b/src/util/config.h.cmake
@@ -32,5 +32,6 @@
 // cfree() does not exist in glibc 2.26+.
 // See: https://bugs.kde.org/show_bug.cgi?id=383889
 #cmakedefine01 HAVE_CFREE
+#cmakedefine01 HAVE_VALLOC
 
 #endif // HEAPTRACK_CONFIG_H

--- a/src/util/linewriter.h
+++ b/src/util/linewriter.h
@@ -27,7 +27,10 @@
 #include <cassert>
 #include <climits>
 #include <cmath>
+#include <string>
 #include <cstring>
+
+#include <errno.h>
 #include <unistd.h>
 
 /**

--- a/tests/auto/CMakeLists.txt
+++ b/tests/auto/CMakeLists.txt
@@ -6,7 +6,6 @@ set(CMAKE_BUILD_TYPE Debug)
 configure_file(tst_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/tst_config.h @ONLY)
 
 include_directories(
-    ${LIBUNWIND_INCLUDE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}/../../
     ${CMAKE_CURRENT_SOURCE_DIR}/../../src
@@ -14,7 +13,7 @@ include_directories(
 add_definitions(-DCATCH_CONFIG_MAIN)
 
 add_executable(tst_trace tst_trace.cpp)
-target_link_libraries(tst_trace ${LIBUNWIND_LIBRARY})
+target_link_libraries(tst_trace heaptrack_unwind)
 add_test(NAME tst_trace COMMAND tst_trace)
 
 if ("${Boost_FILESYSTEM_FOUND}" AND "${Boost_SYSTEM_FOUND}")
@@ -30,7 +29,7 @@ if ("${Boost_FILESYSTEM_FOUND}" AND "${Boost_SYSTEM_FOUND}")
         LINK_PRIVATE
             ${CMAKE_DL_LIBS}
             ${CMAKE_THREAD_LIBS_INIT}
-            ${LIBUNWIND_LIBRARY}
+            heaptrack_unwind
             rt
             ${Boost_SYSTEM_LIBRARY}
             ${Boost_FILESYSTEM_LIBRARY}


### PR DESCRIPTION
Configuring to build on Android, adding option to use of unwind tables instead of libunwind.