### PR TITLE
Declare new hash function in namespace std in order to fix build.

### DIFF
--- a/src/analyze/gui/parser.cpp
+++ b/src/analyze/gui/parser.cpp
@@ -34,7 +34,7 @@ using namespace std;
 
 #if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
 template<>
-struct hash<QString> {
+struct std::hash<QString> {
     std::size_t operator()(const QString &v) const noexcept
     {
         return qHash(v);


### PR DESCRIPTION
Fixes:

.../src/analyze/gui/parser.cpp:37:8: error: explicit specialization of ‘template<class _Tp> struct std::hash’ outside its namespace must use a nested-name-specifier [-fpermissive]
   37 | struct hash<QString> {
      |        ^~~~~~~~~~~~~

seen with GCC 9.2.0 on Arch Linux.