### PR TITLE
FIX: Allow high priv user to profile low priv user process

### DIFF
--- a/src/track/heaptrack.sh.cmake
+++ b/src/track/heaptrack.sh.cmake
@@ -194,6 +194,16 @@ LIBHEAPTRACK_INJECT=$(readlink -f "$LIBHEAPTRACK_INJECT")
 pipe=/tmp/heaptrack_fifo$$
 mkfifo $pipe
 
+# if root is profiling a process for non root
+# give profiled process write access to the pipe
+if [ ! -z "$pid" ]; then
+  pid_user=$(stat -c %U /proc/"$pid")
+  if [ -z "$pid_user" ]; then
+    exit 1
+  fi
+  chown "$pid_user" "$pipe" || exit 1
+fi
+
 output_suffix="gz"
 COMPRESSOR="gzip -c"
 


### PR DESCRIPTION
In some cases `root` may attach to a non `root` process, in that case
we need to ensure th pipe can be written to by the actual process being
profiled

see: https://bugs.kde.org/show_bug.cgi?id=412742