### PR TITLE
Backported fix in handling ".note.gnu.build-id" section

### DIFF
--- a/3rdparty/libbacktrace/elf.c
+++ b/3rdparty/libbacktrace/elf.c
@@ -2761,7 +2761,7 @@ elf_add (struct backtrace_state *state, const char *filename, int descriptor,
 	  if (note->type == NT_GNU_BUILD_ID
 	      && note->namesz == 4
 	      && strncmp (note->name, "GNU", 4) == 0
-	      && shdr->sh_size < 12 + ((note->namesz + 3) & ~ 3) + note->descsz)
+	      && shdr->sh_size <= 12 + ((note->namesz + 3) & ~ 3) + note->descsz)
 	    {
 	      buildid_data = &note->name[0] + ((note->namesz + 3) & ~ 3);
 	      buildid_size = note->descsz;


### PR DESCRIPTION
Build-ID based standalone debug info might be ignored for some shared objects. See details in https://gcc.gnu.org/bugzilla/show_bug.cgi?id=86198