### PR TITLE
track: Check for unw_set_caching_policy before using

### DIFF
--- a/src/track/trace_libunwind.cpp
+++ b/src/track/trace_libunwind.cpp
@@ -26,6 +26,7 @@
 
 #define UNW_LOCAL_ONLY
 #include <libunwind.h>
+#include <inttypes.h>
 
 #include <stdio.h>
 
@@ -60,9 +61,11 @@ void Trace::print()
 void Trace::setup()
 {
     // configure libunwind for better speed
+#if UNW_CACHE_PER_THREAD
     if (unw_set_caching_policy(unw_local_addr_space, UNW_CACHE_PER_THREAD)) {
         fprintf(stderr, "WARNING: Failed to enable per-thread libunwind caching.\n");
     }
+#endif
 #if LIBUNWIND_HAS_UNW_SET_CACHE_SIZE
     if (unw_set_cache_size(unw_local_addr_space, 1024, 0)) {
         fprintf(stderr, "WARNING: Failed to set libunwind cache size.\n");


### PR DESCRIPTION
llvm libunwind does not implement unw_cache_* functions yet
Include inttypes.h got PRI* macros

Signed-off-by: Khem Raj <raj.khem@gmail.com>