### PR TITLE
Bug 379660 Remove template parameters from flamegraph view

### DIFF
--- a/src/analyze/gui/CMakeLists.txt
+++ b/src/analyze/gui/CMakeLists.txt
@@ -29,6 +29,7 @@ add_definitions(-Wall
 add_library(heaptrack_gui_private STATIC
     util.cpp
     parser.cpp
+    middleelide.cpp
 )
 target_link_libraries(heaptrack_gui_private PUBLIC
     KF5::I18n
@@ -75,6 +76,8 @@ set(LIBRARIES
     sharedprint
     heaptrack_gui_private
 )
+
+add_subdirectory(tests)
 
 if (KChart_FOUND)
     list(APPEND SRCFILES

--- a/src/analyze/gui/flamegraph.cpp
+++ b/src/analyze/gui/flamegraph.cpp
@@ -45,6 +45,7 @@
 
 #include "resultdata.h"
 #include "util.h"
+#include "middleelide.h"
 
 enum CostType
 {
@@ -192,10 +193,12 @@ void FrameGraphicsItem::paint(QPainter* painter, const QStyleOptionGraphicsItem*
         Q_UNREACHABLE();
     }();
 
+    QString middleElidedLabel = MiddleElide::elideAngleBracket(label);
+
     const int height = rect().height();
     painter->drawText(margin + rect().x(), rect().y(), width, height,
                       Qt::AlignVCenter | Qt::AlignLeft | Qt::TextSingleLine,
-                      option->fontMetrics.elidedText(label, Qt::ElideRight, width));
+                      option->fontMetrics.elidedText(middleElidedLabel, Qt::ElideRight, width));
 
     if (m_searchMatch == NoMatch) {
         painter->setPen(oldPen);

--- a/src/analyze/gui/middleelide.cpp
+++ b/src/analyze/gui/middleelide.cpp
@@ -1,0 +1,42 @@
+#include "middleelide.h"
+#include <QChar>
+
+MiddleElide::MiddleElide()
+{
+
+}
+
+QString MiddleElide::elideAngleBracket(const QString& s)
+{
+   return substituteAngleBrackets(s);
+}
+
+QString MiddleElide::substituteAngleBrackets(const QString& s)
+{
+    static QChar startBracket = QChar(u'<');
+    static QChar stopBracket  = QChar(u'>');
+
+    int level = 0;
+    QString result;
+    for (int i=0, n = s.length(); i < n; i++)  {
+        QChar currentChar = s[i];
+        if (currentChar == QChar(startBracket) && level == 0) {
+            result += QChar(startBracket);
+            level++;
+        }
+        else if (currentChar == QChar(startBracket) && level > 0) {
+            level++;
+        }
+        else if (currentChar == QChar(stopBracket) && level == 1) {
+            result += QString::fromUtf8("...>");
+            level--;
+        }
+        else if (currentChar == QChar(stopBracket) && level > 1) {
+            level--;
+        }
+        else if (level == 0) {
+            result += currentChar;
+        }
+    }
+    return result;
+}

--- a/src/analyze/gui/middleelide.h
+++ b/src/analyze/gui/middleelide.h
@@ -1,0 +1,17 @@
+#ifndef MIDDLEELIDE_H
+#define MIDDLEELIDE_H
+
+#include <QString>
+
+class MiddleElide
+{
+public:
+    MiddleElide();
+
+    static QString elideAngleBracket(const QString& s);
+
+private:
+    static QString substituteAngleBrackets(const QString& s);
+};
+
+#endif // MIDDLEELIDE_H

--- a/src/analyze/gui/tests/CMakeLists.txt
+++ b/src/analyze/gui/tests/CMakeLists.txt
@@ -1,0 +1,21 @@
+project(test_middle_elide LANGUAGES CXX)
+
+find_package(QT NAMES Qt5 Qt6 COMPONENTS Test REQUIRED)
+find_package(Qt${QT_VERSION_MAJOR} COMPONENTS Test REQUIRED)
+
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+enable_testing()
+
+add_executable(test_middle_elide
+    tst_middle_elide.cpp
+)
+
+add_test(NAME test_middle_elide COMMAND test_middle_elide)
+
+target_link_libraries(test_middle_elide PRIVATE
+                      heaptrack_gui_private
+                      Qt${QT_VERSION_MAJOR}::Test)
+

--- a/src/analyze/gui/tests/tst_middle_elide.cpp
+++ b/src/analyze/gui/tests/tst_middle_elide.cpp
@@ -1,0 +1,64 @@
+#include <QtTest>
+#include <QString>
+#include "analyze/gui/middleelide.h"
+
+// add necessary includes here
+
+const char* simple_case = "MainWindow::onLoadingFinish(unsigned int&)";
+const char* one_bracket = "std::vector<test type in bracket> MainWindow::onLoadingFinish(unsigned int&)";
+const char* one_bracket_fixed = "std::vector<...> MainWindow::onLoadingFinish(unsigned int&)";
+const char* two_brackets = "std::vector<test type in bracket> MainWindow<vector_a>::onLoadingFinish(unsigned int&)";
+const char* two_brackets_fixed = "std::vector<...> MainWindow<...>::onLoadingFinish(unsigned int&)";
+const char* nested_brackets = "std::vector<test type <int> in bracket> MainWindow::onLoadingFinish(unsigned int&)";
+const char* nested_brackets_fixed = "std::vector<...> MainWindow::onLoadingFinish(unsigned int&)";
+
+
+class test_initilaize : public QObject
+{
+    Q_OBJECT
+
+public:
+    test_initilaize() = default;
+    ~test_initilaize() = default;
+
+private slots:
+    void test_simple_case();
+    void test_single_bracket();
+    void test_multiple_brackets();
+    void test_nested_brackets();
+};
+
+void test_initilaize::test_simple_case()
+{
+    QString testString = QString::fromUtf8(simple_case);
+    QString result = MiddleElide::elideAngleBracket(testString);
+    QVERIFY(result == testString);
+}
+
+void test_initilaize::test_single_bracket()
+{
+    QString testString = QString::fromUtf8(one_bracket);
+    QString testStringFixed = QString::fromUtf8(one_bracket_fixed);
+    QString result = MiddleElide::elideAngleBracket(testString);
+    QVERIFY(result == testStringFixed);
+}
+
+void test_initilaize::test_multiple_brackets()
+{
+    QString testString = QString::fromUtf8(two_brackets);
+    QString testStringFixed = QString::fromUtf8(two_brackets_fixed);
+    QString result = MiddleElide::elideAngleBracket(testString);
+    QVERIFY(result == testStringFixed);
+}
+
+void test_initilaize::test_nested_brackets()
+{
+    QString testString = QString::fromUtf8(nested_brackets);
+    QString testStringFixed = QString::fromUtf8(nested_brackets_fixed);
+    QString result = MiddleElide::elideAngleBracket(testString);
+    QVERIFY(result == testStringFixed);
+}
+
+QTEST_APPLESS_MAIN(test_initilaize)
+
+#include "tst_middle_elide.moc"


### PR DESCRIPTION
Added a textfilter which removes the long template parameters as
described in the Bug ticket Bug 379660.
Added unit-tests for filtering the entries and removing the template parameters