### PR TITLE
handle calling heaptrack_stop() without debuginfo

### DIFF
--- a/src/track/heaptrack.sh.cmake
+++ b/src/track/heaptrack.sh.cmake
@@ -277,7 +277,7 @@ cleanup() {
         echo "removing heaptrack injection via GDB, this might take some time..."
         gdb --batch-silent -n -iex="set auto-solib-add off" -p $pid \
             --eval-command="sharedlibrary libheaptrack_inject" \
-            --eval-command="call heaptrack_stop()" \
+            --eval-command="call (void) heaptrack_stop()" \
             --eval-command="detach"
         # NOTE: we do not call dlclose here, as that has the tendency to trigger
         #       crashes in the debuggee. So instead, we keep heaptrack loaded.


### PR DESCRIPTION
If the heaptrack inject binary is stripped (as may easily be the case e.g. with distribution packages), gdb prints out "'heaptrack_stop' has unknown return type; cast the call to its declared return type". Add an explicit cast, like all other gdb calls already use.
