### PR TITLE
1.3

### DIFF
--- a/src/analyze/gui/org.kde.heaptrack.appdata.xml
+++ b/src/analyze/gui/org.kde.heaptrack.appdata.xml
@@ -57,7 +57,7 @@
       Heaptrack traces all memory allocations and annotates these events with stack traces. Dedicated analysis tools then allow you to interpret the heap memory profile to:
     </p>
     <p xml:lang="ca">El «heaptrack» rastreja totes les assignacions de memòria i anota aquests esdeveniments amb seguiments de pila. Les eines d'anàlisi dedicades que hi ha a continuació, us permetran interpretar el perfil de memòria en monticles:</p>
-    <p xml:lang="ca-valencia">El «heaptrack» rastreja totes les assignacions de memòria i anota aquests esdeveniments amb seguiments de pila. Les eines d'anàlisi dedicades que hi ha a continuació, vos permetran interpretar el perfil de memòria en monticles:</p>
+    <p xml:lang="ca-valencia">El «heaptrack» rastreja totes les assignacions de memòria i anota estos esdeveniments amb seguiments de pila. Les eines d'anàlisi dedicades que hi ha a continuació, vos permetran interpretar el perfil de memòria en monticles:</p>
     <p xml:lang="da">Heaptrack sporer alle hukommelsesallokeringer og anmærker begivenhederne med stakspor. Dedikerede analyseværktøjer som giver dig mulighed for at fortolke heapens hukommelsesprofil til:</p>
     <p xml:lang="en-GB">Heaptrack traces all memory allocations and annotates these events with stack traces. Dedicated analysis tools then allow you to interpret the heap memory profile to:</p>
     <p xml:lang="es">Heaptrack rastrea todas las asignaciones de memoria y anota estos eventos con trazas de la pila para poder usar herramientas de dedicadas que le permitan interpretar el análisis de rendimiento de la memoria de almacenamiento libre para:</p>

--- a/src/analyze/gui/org.kde.heaptrack.appdata.xml
+++ b/src/analyze/gui/org.kde.heaptrack.appdata.xml
@@ -181,6 +181,7 @@
       <caption xml:lang="fr">Résumé des données d'allocation pour la mémoire dynamique surveillée.</caption>
       <caption xml:lang="it">Riepilogo dei dati delle allocazioni di memoria heap tracciati</caption>
       <caption xml:lang="nl">Samenvatting van gevolgde gegevens voor heap-geheugen toewijzen</caption>
+      <caption xml:lang="nn">Samandrag av minnereserveringsdata</caption>
       <caption xml:lang="pl">Podsumować śledzonych danych przydzielonych na pamięci stosu</caption>
       <caption xml:lang="pt-BR">Resumo dos dados rastreados de alocação de memória de dados</caption>
       <caption xml:lang="sv">Sammanfattning av spårad heap-minnestilldelningsdata</caption>
@@ -196,6 +197,7 @@
       <caption xml:lang="fr">Affichage graphe en chandelles du nombre d'allocations de mémoire dynamique.</caption>
       <caption xml:lang="it">Visualizzazione di tipo Flamegraph del totale di allocazioni di memoria heap</caption>
       <caption xml:lang="nl">Flamegraph visualisatie van het aantal toewijzingen van heap-geheugen</caption>
+      <caption xml:lang="nn">Flammegraf-visualisering av talet på minnereserveringar</caption>
       <caption xml:lang="pl">Zobrazowanie liczby przydzieleń pamięci na stosie na wykresie płomieni</caption>
       <caption xml:lang="pt-BR">Visualização em gráfico de chamas do número de alocações de memória de dados</caption>
       <caption xml:lang="sv">Visualisering av antal heap-minnestilldelningar med Flamegraph</caption>
@@ -211,6 +213,7 @@
       <caption xml:lang="fr">Graphique des allocations de mémoire dynamique en temps réel</caption>
       <caption xml:lang="it">Grafico delle allocazioni della memoria heap nel tempo</caption>
       <caption xml:lang="nl">Grafiek van toewijzingen van heap-geheugen in de tijd</caption>
+      <caption xml:lang="nn">Diagram over minnereserveringar over tid</caption>
       <caption xml:lang="pl">Wykres przydzieleń pamięci na stosie na osi czasu</caption>
       <caption xml:lang="pt-BR">Gráfico das alocações de memória de dado no período de tempo</caption>
       <caption xml:lang="sv">Diagram över heap-minnestilldelningar över tiden</caption>

--- a/src/analyze/gui/org.kde.heaptrack.appdata.xml
+++ b/src/analyze/gui/org.kde.heaptrack.appdata.xml
@@ -177,6 +177,7 @@
       <caption>Summary of tracked heap memory allocation data</caption>
       <caption xml:lang="ca">Resum del seguiment de les dades d'assignació de la memòria en monticles</caption>
       <caption xml:lang="ca-valencia">Resum del seguiment de les dades d'assignació de la memòria en monticles</caption>
+      <caption xml:lang="en-GB">Summary of tracked heap memory allocation data</caption>
       <caption xml:lang="es">Sumario de datos de asignación de memoria de almacenamiento libre rastreada</caption>
       <caption xml:lang="fr">Résumé des données d'allocation pour la mémoire dynamique surveillée.</caption>
       <caption xml:lang="it">Riepilogo dei dati delle allocazioni di memoria heap tracciati</caption>
@@ -194,6 +195,7 @@
       <caption>Flamegraph visualization of number of heap memory allocations</caption>
       <caption xml:lang="ca">Visualització del gràfic de flames del nombre d'assignacions de memòria en monticles</caption>
       <caption xml:lang="ca-valencia">Visualització del gràfic de flames del nombre d'assignacions de memòria en monticles</caption>
+      <caption xml:lang="en-GB">Flamegraph visualisation of number of heap memory allocations</caption>
       <caption xml:lang="es">Visualización de gráfico de llamas del número de asignaciones de memoria de almacenamiento libre</caption>
       <caption xml:lang="fr">Affichage graphe en chandelles du nombre d'allocations de mémoire dynamique.</caption>
       <caption xml:lang="it">Visualizzazione di tipo Flamegraph del totale di allocazioni di memoria heap</caption>
@@ -211,6 +213,7 @@
       <caption>Chart of heap memory allocations over time</caption>
       <caption xml:lang="ca">Gràfic de les assignacions de memòria en monticles al llarg del temps</caption>
       <caption xml:lang="ca-valencia">Gràfic de les assignacions de memòria en monticles al llarg del temps</caption>
+      <caption xml:lang="en-GB">Chart of heap memory allocations over time</caption>
       <caption xml:lang="es">Gráfico de asignaciones de memoria del almacenamiento libre a lo largo del tiempo</caption>
       <caption xml:lang="fr">Graphique des allocations de mémoire dynamique en temps réel</caption>
       <caption xml:lang="it">Grafico delle allocazioni della memoria heap nel tempo</caption>

--- a/src/analyze/gui/org.kde.heaptrack.appdata.xml
+++ b/src/analyze/gui/org.kde.heaptrack.appdata.xml
@@ -187,6 +187,7 @@
       <caption xml:lang="nn">Samandrag av minnereserveringsdata</caption>
       <caption xml:lang="pl">Podsumować śledzonych danych przydzielonych na pamięci stosu</caption>
       <caption xml:lang="pt-BR">Resumo dos dados rastreados de alocação de memória de dados</caption>
+      <caption xml:lang="sk">Sumár alokačných údajov sledovanej pamäťovej haldy.</caption>
       <caption xml:lang="sl">Povzetek podatkov o dodelitvi pomnilnika v kopici</caption>
       <caption xml:lang="sv">Sammanfattning av spårad heap-minnestilldelningsdata</caption>
       <caption xml:lang="uk">Резюме щодо стеження за розміщенням даних у «купі» пам'яті</caption>
@@ -207,6 +208,7 @@
       <caption xml:lang="nn">Flammegraf-visualisering av talet på minnereserveringar</caption>
       <caption xml:lang="pl">Zobrazowanie liczby przydzieleń pamięci na stosie na wykresie płomieni</caption>
       <caption xml:lang="pt-BR">Visualização em gráfico de chamas do número de alocações de memória de dados</caption>
+      <caption xml:lang="sk">Plameňový graf vizualizácie počtu alokácií pamäťovej hromady.</caption>
       <caption xml:lang="sl">Grafična vizualizacija števila dodelitev pomnilnika v kopici</caption>
       <caption xml:lang="sv">Visualisering av antal heap-minnestilldelningar med Flamegraph</caption>
       <caption xml:lang="uk">Інтерактивна гістограма кількості розміщень у «купі» пам'яті</caption>
@@ -227,6 +229,7 @@
       <caption xml:lang="nn">Diagram over minnereserveringar over tid</caption>
       <caption xml:lang="pl">Wykres przydzieleń pamięci na stosie na osi czasu</caption>
       <caption xml:lang="pt-BR">Gráfico das alocações de memória de dado no período de tempo</caption>
+      <caption xml:lang="sk">Graf alokácií pamäťovej hromady v čase.</caption>
       <caption xml:lang="sl">Graf dodelitev pomnilnika za kopico skozi čas</caption>
       <caption xml:lang="sv">Diagram över heap-minnestilldelningar över tiden</caption>
       <caption xml:lang="uk">Діаграма розміщення даних у «купі» пам'яті за часом</caption>

--- a/src/analyze/gui/org.kde.heaptrack.appdata.xml
+++ b/src/analyze/gui/org.kde.heaptrack.appdata.xml
@@ -57,7 +57,7 @@
       Heaptrack traces all memory allocations and annotates these events with stack traces. Dedicated analysis tools then allow you to interpret the heap memory profile to:
     </p>
     <p xml:lang="ca">El «heaptrack» rastreja totes les assignacions de memòria i anota aquests esdeveniments amb seguiments de pila. Les eines d'anàlisi dedicades que hi ha a continuació, us permetran interpretar el perfil de memòria en monticles:</p>
-    <p xml:lang="ca-valencia">El «heaptrack» rastreja totes les assignacions de memòria i anota estos esdeveniments amb seguiments de pila. Les eines d'anàlisi dedicades que hi ha a continuació, vos permetran interpretar el perfil de memòria en monticles:</p>
+    <p xml:lang="ca-valencia">«heaptrack» rastreja totes les assignacions de memòria i anota estos esdeveniments amb seguiments de pila. Les eines d'anàlisi dedicades que hi ha a continuació, vos permetran interpretar el perfil de memòria en monticles:</p>
     <p xml:lang="da">Heaptrack sporer alle hukommelsesallokeringer og anmærker begivenhederne med stakspor. Dedikerede analyseværktøjer som giver dig mulighed for at fortolke heapens hukommelsesprofil til:</p>
     <p xml:lang="en-GB">Heaptrack traces all memory allocations and annotates these events with stack traces. Dedicated analysis tools then allow you to interpret the heap memory profile to:</p>
     <p xml:lang="es">Heaptrack rastrea todas las asignaciones de memoria y anota estos eventos con trazas de la pila para poder usar herramientas de dedicadas que le permitan interpretar el análisis de rendimiento de la memoria de almacenamiento libre para:</p>

--- a/src/analyze/gui/org.kde.heaptrack.appdata.xml
+++ b/src/analyze/gui/org.kde.heaptrack.appdata.xml
@@ -176,10 +176,12 @@
       <image>https://cdn.kde.org/screenshots/heaptrack/gui_summary.png</image>
       <caption>Summary of tracked heap memory allocation data</caption>
       <caption xml:lang="ca">Resum del seguiment de les dades d'assignació de la memòria en monticles</caption>
+      <caption xml:lang="ca-valencia">Resum del seguiment de les dades d'assignació de la memòria en monticles</caption>
       <caption xml:lang="es">Sumario de datos de asignación de memoria de almacenamiento libre rastreada</caption>
       <caption xml:lang="fr">Résumé des données d'allocation pour la mémoire dynamique surveillée.</caption>
       <caption xml:lang="it">Riepilogo dei dati delle allocazioni di memoria heap tracciati</caption>
       <caption xml:lang="nl">Samenvatting van gevolgde gegevens voor heap-geheugen toewijzen</caption>
+      <caption xml:lang="pl">Podsumować śledzonych danych przydzielonych na pamięci stosu</caption>
       <caption xml:lang="pt-BR">Resumo dos dados rastreados de alocação de memória de dados</caption>
       <caption xml:lang="sv">Sammanfattning av spårad heap-minnestilldelningsdata</caption>
       <caption xml:lang="uk">Резюме щодо стеження за розміщенням даних у «купі» пам'яті</caption>
@@ -189,10 +191,12 @@
       <image>https://cdn.kde.org/screenshots/heaptrack/gui_flamegraph.png</image>
       <caption>Flamegraph visualization of number of heap memory allocations</caption>
       <caption xml:lang="ca">Visualització del gràfic de flames del nombre d'assignacions de memòria en monticles</caption>
+      <caption xml:lang="ca-valencia">Visualització del gràfic de flames del nombre d'assignacions de memòria en monticles</caption>
       <caption xml:lang="es">Visualización de gráfico de llamas del número de asignaciones de memoria de almacenamiento libre</caption>
       <caption xml:lang="fr">Affichage graphe en chandelles du nombre d'allocations de mémoire dynamique.</caption>
       <caption xml:lang="it">Visualizzazione di tipo Flamegraph del totale di allocazioni di memoria heap</caption>
       <caption xml:lang="nl">Flamegraph visualisatie van het aantal toewijzingen van heap-geheugen</caption>
+      <caption xml:lang="pl">Zobrazowanie liczby przydzieleń pamięci na stosie na wykresie płomieni</caption>
       <caption xml:lang="pt-BR">Visualização em gráfico de chamas do número de alocações de memória de dados</caption>
       <caption xml:lang="sv">Visualisering av antal heap-minnestilldelningar med Flamegraph</caption>
       <caption xml:lang="uk">Інтерактивна гістограма кількості розміщень у «купі» пам'яті</caption>
@@ -202,10 +206,12 @@
       <image>https://cdn.kde.org/screenshots/heaptrack/gui_allocations_chart.png</image>
       <caption>Chart of heap memory allocations over time</caption>
       <caption xml:lang="ca">Gràfic de les assignacions de memòria en monticles al llarg del temps</caption>
+      <caption xml:lang="ca-valencia">Gràfic de les assignacions de memòria en monticles al llarg del temps</caption>
       <caption xml:lang="es">Gráfico de asignaciones de memoria del almacenamiento libre a lo largo del tiempo</caption>
       <caption xml:lang="fr">Graphique des allocations de mémoire dynamique en temps réel</caption>
       <caption xml:lang="it">Grafico delle allocazioni della memoria heap nel tempo</caption>
       <caption xml:lang="nl">Grafiek van toewijzingen van heap-geheugen in de tijd</caption>
+      <caption xml:lang="pl">Wykres przydzieleń pamięci na stosie na osi czasu</caption>
       <caption xml:lang="pt-BR">Gráfico das alocações de memória de dado no período de tempo</caption>
       <caption xml:lang="sv">Diagram över heap-minnestilldelningar över tiden</caption>
       <caption xml:lang="uk">Діаграма розміщення даних у «купі» пам'яті за часом</caption>

--- a/src/analyze/gui/org.kde.heaptrack.appdata.xml
+++ b/src/analyze/gui/org.kde.heaptrack.appdata.xml
@@ -180,6 +180,7 @@
       <caption xml:lang="en-GB">Summary of tracked heap memory allocation data</caption>
       <caption xml:lang="es">Sumario de datos de asignación de memoria de almacenamiento libre rastreada</caption>
       <caption xml:lang="fr">Résumé des données d'allocation pour la mémoire dynamique surveillée.</caption>
+      <caption xml:lang="id">Ringkasan data alokasi memori tumpukan yang terlacak</caption>
       <caption xml:lang="it">Riepilogo dei dati delle allocazioni di memoria heap tracciati</caption>
       <caption xml:lang="ko">추적된 힙 메모리 할당 데이터 요약</caption>
       <caption xml:lang="nl">Samenvatting van gevolgde gegevens voor heap-geheugen toewijzen</caption>
@@ -199,6 +200,7 @@
       <caption xml:lang="en-GB">Flamegraph visualisation of number of heap memory allocations</caption>
       <caption xml:lang="es">Visualización de gráfico de llamas del número de asignaciones de memoria de almacenamiento libre</caption>
       <caption xml:lang="fr">Affichage graphe en chandelles du nombre d'allocations de mémoire dynamique.</caption>
+      <caption xml:lang="id">Visualisasi Flamegraph dari jumlah alokasi memori tumpukan</caption>
       <caption xml:lang="it">Visualizzazione di tipo Flamegraph del totale di allocazioni di memoria heap</caption>
       <caption xml:lang="ko">힙 메모리 할당 횟수를 플레임 그래프로 보기</caption>
       <caption xml:lang="nl">Flamegraph visualisatie van het aantal toewijzingen van heap-geheugen</caption>
@@ -218,6 +220,7 @@
       <caption xml:lang="en-GB">Chart of heap memory allocations over time</caption>
       <caption xml:lang="es">Gráfico de asignaciones de memoria del almacenamiento libre a lo largo del tiempo</caption>
       <caption xml:lang="fr">Graphique des allocations de mémoire dynamique en temps réel</caption>
+      <caption xml:lang="id">Bagan alokasi memori tumpukan dari waktu ke waktu</caption>
       <caption xml:lang="it">Grafico delle allocazioni della memoria heap nel tempo</caption>
       <caption xml:lang="ko">시간별 힙 메모리 할당 횟수를 그래프로 보기</caption>
       <caption xml:lang="nl">Grafiek van toewijzingen van heap-geheugen in de tijd</caption>

--- a/src/analyze/gui/org.kde.heaptrack.appdata.xml
+++ b/src/analyze/gui/org.kde.heaptrack.appdata.xml
@@ -181,6 +181,7 @@
       <caption xml:lang="es">Sumario de datos de asignación de memoria de almacenamiento libre rastreada</caption>
       <caption xml:lang="fr">Résumé des données d'allocation pour la mémoire dynamique surveillée.</caption>
       <caption xml:lang="it">Riepilogo dei dati delle allocazioni di memoria heap tracciati</caption>
+      <caption xml:lang="ko">추적된 힙 메모리 할당 데이터 요약</caption>
       <caption xml:lang="nl">Samenvatting van gevolgde gegevens voor heap-geheugen toewijzen</caption>
       <caption xml:lang="nn">Samandrag av minnereserveringsdata</caption>
       <caption xml:lang="pl">Podsumować śledzonych danych przydzielonych na pamięci stosu</caption>
@@ -199,6 +200,7 @@
       <caption xml:lang="es">Visualización de gráfico de llamas del número de asignaciones de memoria de almacenamiento libre</caption>
       <caption xml:lang="fr">Affichage graphe en chandelles du nombre d'allocations de mémoire dynamique.</caption>
       <caption xml:lang="it">Visualizzazione di tipo Flamegraph del totale di allocazioni di memoria heap</caption>
+      <caption xml:lang="ko">힙 메모리 할당 횟수를 플레임 그래프로 보기</caption>
       <caption xml:lang="nl">Flamegraph visualisatie van het aantal toewijzingen van heap-geheugen</caption>
       <caption xml:lang="nn">Flammegraf-visualisering av talet på minnereserveringar</caption>
       <caption xml:lang="pl">Zobrazowanie liczby przydzieleń pamięci na stosie na wykresie płomieni</caption>
@@ -217,6 +219,7 @@
       <caption xml:lang="es">Gráfico de asignaciones de memoria del almacenamiento libre a lo largo del tiempo</caption>
       <caption xml:lang="fr">Graphique des allocations de mémoire dynamique en temps réel</caption>
       <caption xml:lang="it">Grafico delle allocazioni della memoria heap nel tempo</caption>
+      <caption xml:lang="ko">시간별 힙 메모리 할당 횟수를 그래프로 보기</caption>
       <caption xml:lang="nl">Grafiek van toewijzingen van heap-geheugen in de tijd</caption>
       <caption xml:lang="nn">Diagram over minnereserveringar over tid</caption>
       <caption xml:lang="pl">Wykres przydzieleń pamięci na stosie na osi czasu</caption>

--- a/src/analyze/gui/org.kde.heaptrack.appdata.xml
+++ b/src/analyze/gui/org.kde.heaptrack.appdata.xml
@@ -175,14 +175,41 @@
     <screenshot type="default">
       <image>https://cdn.kde.org/screenshots/heaptrack/gui_summary.png</image>
       <caption>Summary of tracked heap memory allocation data</caption>
+      <caption xml:lang="ca">Resum del seguiment de les dades d'assignació de la memòria en monticles</caption>
+      <caption xml:lang="es">Sumario de datos de asignación de memoria de almacenamiento libre rastreada</caption>
+      <caption xml:lang="fr">Résumé des données d'allocation pour la mémoire dynamique surveillée.</caption>
+      <caption xml:lang="it">Riepilogo dei dati delle allocazioni di memoria heap tracciati</caption>
+      <caption xml:lang="nl">Samenvatting van gevolgde gegevens voor heap-geheugen toewijzen</caption>
+      <caption xml:lang="pt-BR">Resumo dos dados rastreados de alocação de memória de dados</caption>
+      <caption xml:lang="sv">Sammanfattning av spårad heap-minnestilldelningsdata</caption>
+      <caption xml:lang="uk">Резюме щодо стеження за розміщенням даних у «купі» пам'яті</caption>
+      <caption xml:lang="x-test">xxSummary of tracked heap memory allocation dataxx</caption>
     </screenshot>
     <screenshot>
       <image>https://cdn.kde.org/screenshots/heaptrack/gui_flamegraph.png</image>
       <caption>Flamegraph visualization of number of heap memory allocations</caption>
+      <caption xml:lang="ca">Visualització del gràfic de flames del nombre d'assignacions de memòria en monticles</caption>
+      <caption xml:lang="es">Visualización de gráfico de llamas del número de asignaciones de memoria de almacenamiento libre</caption>
+      <caption xml:lang="fr">Affichage graphe en chandelles du nombre d'allocations de mémoire dynamique.</caption>
+      <caption xml:lang="it">Visualizzazione di tipo Flamegraph del totale di allocazioni di memoria heap</caption>
+      <caption xml:lang="nl">Flamegraph visualisatie van het aantal toewijzingen van heap-geheugen</caption>
+      <caption xml:lang="pt-BR">Visualização em gráfico de chamas do número de alocações de memória de dados</caption>
+      <caption xml:lang="sv">Visualisering av antal heap-minnestilldelningar med Flamegraph</caption>
+      <caption xml:lang="uk">Інтерактивна гістограма кількості розміщень у «купі» пам'яті</caption>
+      <caption xml:lang="x-test">xxFlamegraph visualization of number of heap memory allocationsxx</caption>
     </screenshot>
     <screenshot>
       <image>https://cdn.kde.org/screenshots/heaptrack/gui_allocations_chart.png</image>
       <caption>Chart of heap memory allocations over time</caption>
+      <caption xml:lang="ca">Gràfic de les assignacions de memòria en monticles al llarg del temps</caption>
+      <caption xml:lang="es">Gráfico de asignaciones de memoria del almacenamiento libre a lo largo del tiempo</caption>
+      <caption xml:lang="fr">Graphique des allocations de mémoire dynamique en temps réel</caption>
+      <caption xml:lang="it">Grafico delle allocazioni della memoria heap nel tempo</caption>
+      <caption xml:lang="nl">Grafiek van toewijzingen van heap-geheugen in de tijd</caption>
+      <caption xml:lang="pt-BR">Gráfico das alocações de memória de dado no período de tempo</caption>
+      <caption xml:lang="sv">Diagram över heap-minnestilldelningar över tiden</caption>
+      <caption xml:lang="uk">Діаграма розміщення даних у «купі» пам'яті за часом</caption>
+      <caption xml:lang="x-test">xxChart of heap memory allocations over timexx</caption>
     </screenshot>
   </screenshots>
   <project_group>KDE</project_group>

--- a/src/analyze/gui/org.kde.heaptrack.appdata.xml
+++ b/src/analyze/gui/org.kde.heaptrack.appdata.xml
@@ -184,6 +184,7 @@
       <caption xml:lang="nn">Samandrag av minnereserveringsdata</caption>
       <caption xml:lang="pl">Podsumować śledzonych danych przydzielonych na pamięci stosu</caption>
       <caption xml:lang="pt-BR">Resumo dos dados rastreados de alocação de memória de dados</caption>
+      <caption xml:lang="sl">Povzetek podatkov o dodelitvi pomnilnika v kopici</caption>
       <caption xml:lang="sv">Sammanfattning av spårad heap-minnestilldelningsdata</caption>
       <caption xml:lang="uk">Резюме щодо стеження за розміщенням даних у «купі» пам'яті</caption>
       <caption xml:lang="x-test">xxSummary of tracked heap memory allocation dataxx</caption>
@@ -200,6 +201,7 @@
       <caption xml:lang="nn">Flammegraf-visualisering av talet på minnereserveringar</caption>
       <caption xml:lang="pl">Zobrazowanie liczby przydzieleń pamięci na stosie na wykresie płomieni</caption>
       <caption xml:lang="pt-BR">Visualização em gráfico de chamas do número de alocações de memória de dados</caption>
+      <caption xml:lang="sl">Grafična vizualizacija števila dodelitev pomnilnika v kopici</caption>
       <caption xml:lang="sv">Visualisering av antal heap-minnestilldelningar med Flamegraph</caption>
       <caption xml:lang="uk">Інтерактивна гістограма кількості розміщень у «купі» пам'яті</caption>
       <caption xml:lang="x-test">xxFlamegraph visualization of number of heap memory allocationsxx</caption>
@@ -216,6 +218,7 @@
       <caption xml:lang="nn">Diagram over minnereserveringar over tid</caption>
       <caption xml:lang="pl">Wykres przydzieleń pamięci na stosie na osi czasu</caption>
       <caption xml:lang="pt-BR">Gráfico das alocações de memória de dado no período de tempo</caption>
+      <caption xml:lang="sl">Graf dodelitev pomnilnika za kopico skozi čas</caption>
       <caption xml:lang="sv">Diagram över heap-minnestilldelningar över tiden</caption>
       <caption xml:lang="uk">Діаграма розміщення даних у «купі» пам'яті за часом</caption>
       <caption xml:lang="x-test">xxChart of heap memory allocations over timexx</caption>

--- a/src/analyze/gui/org.kde.heaptrack.appdata.xml
+++ b/src/analyze/gui/org.kde.heaptrack.appdata.xml
@@ -33,7 +33,6 @@
   <summary>A heap memory profiler for Linux</summary>
   <summary xml:lang="ca">Un perfilador de memòria en monticles per a Linux</summary>
   <summary xml:lang="ca-valencia">Un perfilador de memòria en monticles per a Linux</summary>
-  <summary xml:lang="da">En heap-hukommelsesprofilering til Linux</summary>
   <summary xml:lang="en-GB">A heap memory profiler for Linux</summary>
   <summary xml:lang="es">Un analizador de rendimiento de la memoria de almacenamiento libre para Linux</summary>
   <summary xml:lang="fr">Un analyseur de mémoire dynamique pour Linux</summary>
@@ -47,10 +46,9 @@
   <summary xml:lang="pl">Program profilujący pamięć na stosie dla Linuksa</summary>
   <summary xml:lang="pt">Um analisador da memória de dados para o Linux</summary>
   <summary xml:lang="pt-BR">Um analisador de performance de memória de dados para o Linux</summary>
-  <summary xml:lang="sk">Profiler pamäťovej haldy pre Linux</summary>
+  <summary xml:lang="sk">Profiler pamäťovej haldy pre Linux.</summary>
   <summary xml:lang="sl">Analizator profila pomnilnika kopice za Linux</summary>
   <summary xml:lang="sv">Ett heap-profileringsverktyg för Linux</summary>
-  <summary xml:lang="tr">Linux için yığın bellek profili</summary>
   <summary xml:lang="uk">Засіб профілювання «купи» пам'яті для Linux</summary>
   <summary xml:lang="x-test">xxA heap memory profiler for Linuxxx</summary>
   <summary xml:lang="zh-CN">用于 Linux 的堆内存分析器</summary>
@@ -68,7 +66,7 @@
     <p xml:lang="id">Heaptrack melacak semua alokasi memori dan membubuhi keterangan peristiwa ini dengan jejak tumpukan. Alat analisis khusus kemudian memungkinkan kamu untuk menginterpretasikan profil memori tumpukan untuk:</p>
     <p xml:lang="it">Heaptrack traccia tutte le allocazioni di memoria e le annota con tracciati dello stack. Degli strumenti dedicati di analisi ti permettono quindi di interpretare il profilo della memoria heap in modo da:</p>
     <p xml:lang="ko">힙 추적은 모든 메모리 할당을 추적하고 스택 추적과 메모리 할당을 연결합니다. 분석 도구를 사용하여 힙 메모리 프로필을 해석할 수 있습니다:</p>
-    <p xml:lang="nl">Heaptrack traceert alle toewijzingen van geheugen en annoteert deze gebeurtenissen met stacktraces. Specifieke hulpmiddelen voor analyse bieden u de mogelijkheid om het geheugenprofiel van de heap te interpreteren:</p>
+    <p xml:lang="nl">Heaptrack traceert alle toewijzigingen van geheugen en annoteert deze gebeurtenissen met stacktraces. Specifieke hulpmiddelen voor analyse bieden u de mogelijkheid om het geheugenprofiel van de heap te interpreteren:</p>
     <p xml:lang="nn">Heaptrack sporar alle minnereserveringar og merkjer dei med tilhøyrande stabelspor. Analyseverktøyet lèt deg så tolka minneprofilen for å:</p>
     <p xml:lang="pl">Heaptrack rejestruje wszystkie przydziały pamięci i przypisuje tym zdarzeniom ślady stosu. Dedykowane narzędzia analizy, które umożliwiają interpretację profilu pamięcy aby:</p>
     <p xml:lang="pt">O Heaptrack faz uma análise de todas as alocações de memória e anota esses eventos com os registos de chamadas. As ferramentas de análise dedicadas permitem-lhe então interpretar o perfil da memória de dados para:</p>
@@ -177,65 +175,14 @@
     <screenshot type="default">
       <image>https://cdn.kde.org/screenshots/heaptrack/gui_summary.png</image>
       <caption>Summary of tracked heap memory allocation data</caption>
-      <caption xml:lang="ca">Resum del seguiment de les dades d'assignació de la memòria en monticles</caption>
-      <caption xml:lang="ca-valencia">Resum del seguiment de les dades d'assignació de la memòria en monticles</caption>
-      <caption xml:lang="en-GB">Summary of tracked heap memory allocation data</caption>
-      <caption xml:lang="es">Sumario de datos de asignación de memoria de almacenamiento libre rastreada</caption>
-      <caption xml:lang="fr">Résumé des données d'allocation pour la mémoire dynamique surveillée.</caption>
-      <caption xml:lang="id">Ringkasan data alokasi memori tumpukan yang terlacak</caption>
-      <caption xml:lang="it">Riepilogo dei dati delle allocazioni di memoria heap tracciati</caption>
-      <caption xml:lang="ko">추적된 힙 메모리 할당 데이터 요약</caption>
-      <caption xml:lang="nl">Samenvatting van gevolgde gegevens voor heap-geheugen toewijzen</caption>
-      <caption xml:lang="nn">Samandrag av minnereserveringsdata</caption>
-      <caption xml:lang="pl">Podsumować śledzonych danych przydzielonych na pamięci stosu</caption>
-      <caption xml:lang="pt">Um resumo dos dados de alocação de memória de dados registados</caption>
-      <caption xml:lang="pt-BR">Resumo dos dados rastreados de alocação de memória de dados</caption>
-      <caption xml:lang="sl">Povzetek podatkov o dodelitvi pomnilnika v kopici</caption>
-      <caption xml:lang="sv">Sammanfattning av spårad heap-minnestilldelningsdata</caption>
-      <caption xml:lang="uk">Резюме щодо стеження за розміщенням даних у «купі» пам'яті</caption>
-      <caption xml:lang="x-test">xxSummary of tracked heap memory allocation dataxx</caption>
     </screenshot>
     <screenshot>
       <image>https://cdn.kde.org/screenshots/heaptrack/gui_flamegraph.png</image>
       <caption>Flamegraph visualization of number of heap memory allocations</caption>
-      <caption xml:lang="ca">Visualització del gràfic de flames del nombre d'assignacions de memòria en monticles</caption>
-      <caption xml:lang="ca-valencia">Visualització del gràfic de flames del nombre d'assignacions de memòria en monticles</caption>
-      <caption xml:lang="en-GB">Flamegraph visualisation of number of heap memory allocations</caption>
-      <caption xml:lang="es">Visualización de gráfico de llamas del número de asignaciones de memoria de almacenamiento libre</caption>
-      <caption xml:lang="fr">Affichage graphe en chandelles du nombre d'allocations de mémoire dynamique.</caption>
-      <caption xml:lang="id">Visualisasi Flamegraph dari jumlah alokasi memori tumpukan</caption>
-      <caption xml:lang="it">Visualizzazione di tipo Flamegraph del totale di allocazioni di memoria heap</caption>
-      <caption xml:lang="ko">힙 메모리 할당 횟수를 플레임 그래프로 보기</caption>
-      <caption xml:lang="nl">Flamegraph visualisatie van het aantal toewijzingen van heap-geheugen</caption>
-      <caption xml:lang="nn">Flammegraf-visualisering av talet på minnereserveringar</caption>
-      <caption xml:lang="pl">Zobrazowanie liczby przydzieleń pamięci na stosie na wykresie płomieni</caption>
-      <caption xml:lang="pt">Uma visualização em mapa de calor das alocações de memória de dados</caption>
-      <caption xml:lang="pt-BR">Visualização em gráfico de chamas do número de alocações de memória de dados</caption>
-      <caption xml:lang="sl">Grafična vizualizacija števila dodelitev pomnilnika v kopici</caption>
-      <caption xml:lang="sv">Visualisering av antal heap-minnestilldelningar med Flamegraph</caption>
-      <caption xml:lang="uk">Інтерактивна гістограма кількості розміщень у «купі» пам'яті</caption>
-      <caption xml:lang="x-test">xxFlamegraph visualization of number of heap memory allocationsxx</caption>
     </screenshot>
     <screenshot>
       <image>https://cdn.kde.org/screenshots/heaptrack/gui_allocations_chart.png</image>
       <caption>Chart of heap memory allocations over time</caption>
-      <caption xml:lang="ca">Gràfic de les assignacions de memòria en monticles al llarg del temps</caption>
-      <caption xml:lang="ca-valencia">Gràfic de les assignacions de memòria en monticles al llarg del temps</caption>
-      <caption xml:lang="en-GB">Chart of heap memory allocations over time</caption>
-      <caption xml:lang="es">Gráfico de asignaciones de memoria del almacenamiento libre a lo largo del tiempo</caption>
-      <caption xml:lang="fr">Graphique des allocations de mémoire dynamique en temps réel</caption>
-      <caption xml:lang="id">Bagan alokasi memori tumpukan dari waktu ke waktu</caption>
-      <caption xml:lang="it">Grafico delle allocazioni della memoria heap nel tempo</caption>
-      <caption xml:lang="ko">시간별 힙 메모리 할당 횟수를 그래프로 보기</caption>
-      <caption xml:lang="nl">Grafiek van toewijzingen van heap-geheugen in de tijd</caption>
-      <caption xml:lang="nn">Diagram over minnereserveringar over tid</caption>
-      <caption xml:lang="pl">Wykres przydzieleń pamięci na stosie na osi czasu</caption>
-      <caption xml:lang="pt">Gráfico das alocações de memória de dados ao longo do tempo</caption>
-      <caption xml:lang="pt-BR">Gráfico das alocações de memória de dado no período de tempo</caption>
-      <caption xml:lang="sl">Tabela dodelitev pomnilnika za kopico skozi čas</caption>
-      <caption xml:lang="sv">Diagram över heap-minnestilldelningar över tiden</caption>
-      <caption xml:lang="uk">Діаграма розміщення даних у «купі» пам'яті за часом</caption>
-      <caption xml:lang="x-test">xxChart of heap memory allocations over timexx</caption>
     </screenshot>
   </screenshots>
   <project_group>KDE</project_group>


### PR DESCRIPTION
kb@debian11:~/QuoteST$ /home/kb/heaptrack-1.3.0/build/bin/heaptrack ./QuoteSvr
heaptrack output will be written to "/home/kb/QuoteST/heaptrack.QuoteSvr.3353971.gz"
/home/kb/heaptrack-1.3.0/build/lib/heaptrack/libheaptrack_preload.so
starting application, this might take some time...
./QuoteSvr: symbol lookup error: /home/kb/heaptrack-1.3.0/build/lib/heaptrack/libheaptrack_preload.so: undefined symbol: _ULx86_64_set_cache_size



When I run the above command, it prompts "symbol lookup error", then the program have been blocking here. no any result display.


My env:
Linux debian11 5.10.0-10-amd64 #1 SMP Debian 5.10.84-1 (2021-12-08) x86_64 GNU/Linux
