### PR TITLE
Use boost::hash_value for IndexedAllocationInfo

### DIFF
--- a/src/util/pointermap.h
+++ b/src/util/pointermap.h
@@ -12,6 +12,7 @@
 #include <limits>
 #include <vector>
 
+#include <boost/functional/hash/hash.hpp>
 #include <tsl/robin_map.h>
 #include <tsl/robin_set.h>
 
@@ -32,25 +33,14 @@ struct IndexedAllocationInfo
     }
 };
 
-// see: https://stackoverflow.com/a/2595226/35250
-template <class T>
-inline void hashCombine(std::size_t& seed, const T& v)
-{
-    std::hash<T> hasher;
-    seed ^= hasher(v) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-}
-
 namespace std {
 template <>
 struct hash<IndexedAllocationInfo>
 {
     size_t operator()(const IndexedAllocationInfo& info) const
     {
-        size_t seed = 0;
-        hashCombine(seed, info.size);
-        hashCombine(seed, info.traceIndex.index);
         // allocationInfoIndex not hashed to allow to look it up
-        return seed;
+        return boost::hash_value(std::tie(info.size, info.traceIndex.index));
     }
 };
 }


### PR DESCRIPTION
The current implementation doesn't really work well with 64-bits values, and can lead to the robin-set using excessive amounts of memory because of the number of collisions that can happen.

See https://bugs.kde.org/show_bug.cgi?id=477018