### PR TITLE
use user ID instead of name

### DIFF
--- a/src/track/heaptrack.sh.cmake
+++ b/src/track/heaptrack.sh.cmake
@@ -267,7 +267,7 @@ mkfifo $pipe
 if [ ! -z "$pid" ]; then
   case $(uname) in
     Linux*)
-      pid_user=$(stat -c %U "/proc/$pid")
+      pid_user=$(stat -c %u "/proc/$pid")
     ;;
     FreeBSD*)
       pid_user=$(stat -f %Su "/proc/$pid")


### PR DESCRIPTION
Discovered that when using heaptrack across docker containers with shared PID namespaces the following error is produced:
```
$ heaptrack -p <some-PID>

chown: invalid user: 'UNKNOWN'
```
This simple change enables usage of heaptrack in this scenario