### PR TITLE
Check stringId.index before accessing the string

### DIFF
--- a/src/analyze/accumulatedtracedata.cpp
+++ b/src/analyze/accumulatedtracedata.cpp
@@ -91,7 +91,7 @@ AccumulatedTraceData::~AccumulatedTraceData() = default;
 
 const string& AccumulatedTraceData::stringify(const StringIndex stringId) const
 {
-    if (!stringId || stringId.index > strings.size()) {
+    if (!stringId || stringId.index > strings.size() || stringId.index <= 0) {
         static const string empty;
         return empty;
     } else {


### PR DESCRIPTION
This PR adds checking for the case where `stringId.index` is less than 1.