### PR TITLE
fix `logic_error` when path is null

### DIFF
--- a/src/interpret/dwarfdiecache.cpp
+++ b/src/interpret/dwarfdiecache.cpp
@@ -222,7 +222,10 @@ std::string demangle(const std::string& mangledName)
 
 std::string absoluteSourcePath(const char* path, Dwarf_Die* cuDie)
 {
-    if (!path || !cuDie || path[0] == '/')
+    if (!path)
+        return "";
+
+    if (!cuDie || path[0] == '/')
         return path;
 
     Dwarf_Attribute attr;


### PR DESCRIPTION
When trying to allocate `std::string` from null:
```
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string: construction from null is not valid
```