### PR TITLE
perf: add thread-local TraceCache to skip redundant TraceTree lookups

### DIFF
--- a/src/track/libheaptrack.cpp
+++ b/src/track/libheaptrack.cpp
@@ -39,6 +39,7 @@
 #include <string>
 #include <thread>
 
+#include "trace_cache.h"
 #include "tracetree.h"
 #include "util/config.h"
 #include "util/libunwind_config.h"
@@ -112,6 +113,13 @@ struct RecursionGuard
 };
 
 thread_local bool RecursionGuard::isActive = false;
+
+/**
+ * Per-thread cache of backtrace → TraceTree index mappings.
+ * Avoids the shared TraceTree trie walk for repeated backtraces
+ * without any lock contention.
+ */
+static thread_local TraceCache t_traceCache;
 
 enum DebugVerbosity
 {
@@ -526,15 +534,21 @@ public:
         }
         updateModuleCache();
 
-        const auto index = s_data->traceTree.index(trace, [](uintptr_t ip, uint32_t index) {
-            // decrement addresses by one - otherwise we misattribute the cost to the wrong instruction
-            // for some reason, it seems like we always get the instruction _after_ the one we are interested in
-            // see also: https://github.com/libunwind/libunwind/issues/287
-            // and https://bugs.kde.org/show_bug.cgi?id=439897
-            --ip;
+        uint32_t index = t_traceCache.lookup(trace);
+        if (!index) {
+            index = s_data->traceTree.index(trace, [](uintptr_t ip, uint32_t idx) {
+                // decrement addresses by one - otherwise we misattribute the cost to the wrong instruction
+                // for some reason, it seems like we always get the instruction _after_ the one we are interested in
+                // see also: https://github.com/libunwind/libunwind/issues/287
+                // and https://bugs.kde.org/show_bug.cgi?id=439897
+                --ip;
 
-            return s_data->out.writeHexLine('t', ip, index);
-        });
+                return s_data->out.writeHexLine('t', ip, idx);
+            });
+            if (index) {
+                t_traceCache.store(trace, index);
+            }
+        }
 
 #ifdef DEBUG_MALLOC_PTRS
         auto it = s_data->known.find(ptr);

--- a/src/track/trace.h
+++ b/src/track/trace.h
@@ -8,6 +8,7 @@
 #define TRACE_H
 
 #include <cassert>
+#include <cstddef>
 #include <cstdint>
 
 /**
@@ -42,6 +43,11 @@ struct Trace
         return m_size;
     }
 
+    size_t hashkey() const
+    {
+        return m_key;
+    }
+
     bool fill(int skip)
     {
         int size = unwind(m_data);
@@ -52,6 +58,7 @@ struct Trace
         }
         m_size = size > skip ? size - skip : 0;
         m_skip = skip;
+        m_key = getHashKey();
         return m_size > 0;
     }
 
@@ -65,6 +72,7 @@ struct Trace
 
         m_size = static_cast<int>(n + 1);
         m_skip = 0;
+        m_key = getHashKey();
     }
 
     static void setup();
@@ -77,7 +85,16 @@ private:
 private:
     int m_size = 0;
     int m_skip = 0;
+    size_t m_key = 0;
     ip_t m_data[MAX_SIZE];
+
+    size_t getHashKey() const
+    {
+        size_t h = (size_t)m_size * 0xbb67ae8584caa73bULL;
+        for (int i = 0; i < m_size; ++i)
+            h = h * 0xbb67ae8584caa73bULL + ((uintptr_t)m_data[m_skip + i] >> 4);
+        return h;
+    }
 };
 
 #endif // TRACE_H

--- a/src/track/trace_cache.h
+++ b/src/track/trace_cache.h
@@ -1,0 +1,122 @@
+#ifndef TRACECACHE_H
+#define TRACECACHE_H
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstring>
+
+#include "trace.h"
+
+/**
+ * A small, fixed-size LRU cache mapping backtraces to TraceTree indices.
+ *
+ * Placed in front of TraceTree::index() to skip expensive trie walks for
+ * repeated backtraces. Uses a 32-bit hash key with IP-level verification
+ * (first HASH_DEPTH frames via memcmp) to prevent false positives. Eviction
+ * uses a decay counter: each miss decays the LRU tail by 25%, entries drop
+ * below HITS_THRESHOLD after ~4 consecutive misses and become eligible for
+ * replacement.
+ *
+ * Cache-line layout is optimized for the hot path: m_key in CL0 is always
+ * read; m_hitCount/m_index in CL1 are only touched on hit; m_ips in CL2-5
+ * are only read after a key match.
+ */
+class alignas(64) TraceCache
+{
+public:
+    static constexpr uint32_t HITS_THRESHOLD = 4;
+    static constexpr uint32_t HITS_INITIAL = 8;
+    static constexpr int HASH_DEPTH = 4;
+
+    // Returns 0 on miss. On hit: increment hits, bubble up one position.
+    [[gnu::always_inline]] uint32_t lookup(const Trace& trace)
+    {
+        const size_t key = trace.hashkey();
+        const Trace::ip_t* const ips = trace.begin();
+        const int depth = std::min(trace.size(), HASH_DEPTH);
+
+        int match = -1;
+        for (int i = 0; i < SIZE; ++i) {
+            if (m_key[i] == key) {
+                match = i;
+                break;
+            }
+        }
+
+        if (match < 0)
+            return 0;
+
+        // Compare IPs: fast path when depth == HASH_DEPTH uses memcmp
+        if (__builtin_expect(depth == HASH_DEPTH, 1)) {
+            if (memcmp(m_ips[match].data(), ips, HASH_DEPTH * sizeof(Trace::ip_t)) != 0)
+                return 0;
+        } else {
+            if (memcmp(m_ips[match].data(), ips, depth * sizeof(Trace::ip_t)) != 0)
+                return 0;
+        }
+
+        ++m_hitCount[match];
+        const int rank = m_lruRank[match];
+        if (rank > 0) {
+            const int prevSlot = m_lruSlot[rank - 1];
+            m_lruSlot[rank] = prevSlot;
+            m_lruSlot[rank - 1] = match;
+            m_lruRank[prevSlot] = rank;
+            m_lruRank[match] = rank - 1;
+        }
+
+        return m_index[match];
+    }
+
+    // Decay the LRU tail's hit counter; evict only when it drops below HITS_THRESHOLD.
+    [[gnu::always_inline]] void store(const Trace& trace, uint32_t index)
+    {
+        assert(index != 0);
+        const int victim = m_lruSlot[SIZE - 1];
+
+        if (m_index[victim] != 0) {
+            m_hitCount[victim] -= m_hitCount[victim] >> 2;
+            if (m_hitCount[victim] >= HITS_THRESHOLD)
+                return;
+        }
+
+        m_key[victim] = trace.hashkey();
+        m_hitCount[victim] = HITS_INITIAL;
+        m_index[victim] = index;
+        const int depth = std::min(trace.size(), HASH_DEPTH);
+        m_ips[victim] = {};
+        memcpy(m_ips[victim].data(), trace.begin(), depth * sizeof(Trace::ip_t));
+    }
+
+    void clear()
+    {
+        for (int i = 0; i < SIZE; ++i) {
+            m_key[i] = 0;
+            m_hitCount[i] = 0;
+            m_index[i] = 0;
+            m_ips[i] = {};
+            m_lruSlot[i] = i;
+            m_lruRank[i] = i;
+        }
+    }
+
+private:
+    static constexpr int SIZE = 8;
+
+    // CL0 (hot): m_key[8] = 64 bytes, read on every lookup
+    size_t m_key[SIZE] = {};
+    // CL1 (warm): m_hitCount[8] + m_index[8] = 64 bytes, read/write on hit
+    uint32_t m_hitCount[SIZE] = {};
+    uint32_t m_index[SIZE] = {};
+    // CL2-5 (cold): m_ips[8] = 256 bytes, read only after key match
+    std::array<Trace::ip_t, HASH_DEPTH> m_ips[SIZE] = {};
+    // CL6: m_lruSlot[8] + m_lruRank[8] = 16 bytes, read/write on hit
+    //   m_lruSlot[rank] -> cache slot at LRU rank  (0 = MRU, SIZE-1 = LRU)
+    //   m_lruRank[slot] -> LRU rank of cache slot
+    uint8_t m_lruSlot[SIZE] = {0, 1, 2, 3, 4, 5, 6, 7};
+    uint8_t m_lruRank[SIZE] = {0, 1, 2, 3, 4, 5, 6, 7};
+};
+
+#endif // TRACECACHE_H


### PR DESCRIPTION
In allocation-heavy workloads, every malloc/free must walk the shared TraceTree trie to resolve its backtrace. This lookup holds a lock and consumes significant critical-section time, causing contention under multi-threaded workloads.

However, high-frequency allocation paths tend to be highly repetitive — the same call site allocating in a loop, the same function calling malloc repeatedly. The backtrace is identical every time, yet we pay the full cost of walking the trie on each call.

This PR inserts a thread-local 8-entry LRU cache in front of TraceTree::index() to skip redundant trie traversals. A cache hit avoids both the trie walk and the associated lock contention entirely.

Implementation:

Key: hash of the backtrace (Murmur-style via 0xbb67ae8584caa73b), with memcmp verification of the first 4 IP frames to eliminate false positives from hash collisions.
Eviction: decay-based rather than exact LRU — each miss decays the tail entry's hit counter by 25%; entries drop below the replacement threshold after ~4 consecutive misses. Hot entries resist eviction naturally.
Cache-line aware layout: key[] in the first cache line (read on every lookup), hitCount/index in the second (touched only on hit), IP storage in colder lines — minimizing cache misses on the fast path.
Lock-free: thread_local storage means zero contention, unlike any shared cache structure.

Performance：

This is the flame graph proportion for /heaptrack/tests/manual/threaded.cpp. It can be clearly seen that the proportion of the TraceTree::index function within the heaptrack_malloc function has decreased from 31.1% to 0.4%.

without cache:
<img width="1551" height="394" alt="图片" src="https://github.com/user-attachments/assets/91b60a2f-c4ff-4760-8827-b522e0bdd691" />

with cache:
<img width="1550" height="391" alt="图片" src="https://github.com/user-attachments/assets/e5d490f8-4986-45e1-b204-663723266e3e" />

I found This idea was originally suggested in [#13](https://github.com/KDE/heaptrack/pull/13) but never landed