### PR TITLE
Performance Improvements

### DIFF
--- a/src/track/heaptrack.sh.cmake
+++ b/src/track/heaptrack.sh.cmake
@@ -36,6 +36,10 @@ usage() {
     echo
     echo "Optional arguments to heaptrack:"
     echo "  -r, --raw      Only record raw data, do not interpret it."
+    echo " --unwind-depth DEPTH"
+    echo "                 Limit backtraces to DEPTH frames per allocation (1..64, default: 64)."
+    echo "                 Smaller depths reduce the tracking overhead."
+    echo "                 Only takes effect for newly started processes, not with --pid."
     echo "  -d, --debug    Run the debuggee in GDB and heaptrack."
     echo " --use-inject    Use the same heaptrack_inject symbol interception mechanism instead of relying on"
     echo "                 the dynamic linker and LD_PRELOAD. This is an experimental flag for now."
@@ -72,6 +76,7 @@ pid=
 client=
 use_inject_lib=
 write_raw_data=
+unwind_depth=
 record_only=
 asan=
 asan_ld_preload=
@@ -168,6 +173,20 @@ while true; do
         "-r" | "--raw")
             write_raw_data=1
             shift 1
+            ;;
+        "--unwind-depth")
+            case "$2" in
+                ''|*[!0-9]*)
+                    echo "Invalid --unwind-depth argument: \"$2\" (expected 1..64)"
+                    exit 1
+                    ;;
+            esac
+            if [ "$2" -lt 1 ] || [ "$2" -gt 64 ]; then
+                echo "Invalid --unwind-depth argument: \"$2\" (expected 1..64)"
+                exit 1
+            fi
+            unwind_depth=$2
+            shift 2
             ;;
         "--asan")
             asan=1
@@ -426,6 +445,10 @@ trap cleanup EXIT INT TERM
 
 if [ -z ${quiet} ]; then
   echo "heaptrack output will be written to \"$output\""
+fi
+
+if [ ! -z "$unwind_depth" ]; then
+    export HEAPTRACK_UNWIND_DEPTH="$unwind_depth"
 fi
 
 if [ -z "$debug" ] && [ -z "$pid" ]; then

--- a/src/track/libheaptrack.cpp
+++ b/src/track/libheaptrack.cpp
@@ -304,6 +304,16 @@ public:
 
             Trace::setup();
 
+            if (const char* depthStr = getenv("HEAPTRACK_UNWIND_DEPTH")) {
+                const int depth = atoi(depthStr);
+                if (depth >= 1 && depth <= Trace::MAX_SIZE) {
+                    Trace::setMaxDepth(depth);
+                } else {
+                    fprintf(stderr, "heaptrack: ignoring invalid HEAPTRACK_UNWIND_DEPTH=%s (expected 1..%d)\n",
+                            depthStr, Trace::MAX_SIZE);
+                }
+            }
+
             // do not trace forked child processes
             // TODO: make this configurable
             pthread_atfork(&prepare_fork, &parent_fork, &child_fork);

--- a/src/track/libheaptrack.cpp
+++ b/src/track/libheaptrack.cpp
@@ -661,7 +661,8 @@ private:
     };
 
     /**
-     * To prevent deadlocks on shutdown, we try to lock from the timer thread
+     * To prevent deadlocks on shutdown, we periodically give up waiting for
+     * the lock to run the stopLockCheck.
      *
      * TODO: c++17 return std::optional<HeapTrack>
      */
@@ -669,11 +670,14 @@ private:
     static LockStatus tryLock(StopLockCheck stopLockCheck)
     {
         debugLog<VeryVerboseOutput>("%s", "trying to acquire lock");
-        while (!s_lock.try_lock()) {
+        // wait on the lock via a futex instead of polling with tiny sleeps:
+        // the kernel's default timer slack inflates a 1us sleep to ~50us,
+        // which heavily delays contended allocations. The timeout only
+        // bounds how long a pending shutdown can go unnoticed.
+        while (!s_lock.try_lock_for(chrono::milliseconds(1))) {
             if (stopLockCheck()) {
                 return false;
             }
-            this_thread::sleep_for(chrono::microseconds(1));
         }
         debugLog<VeryVerboseOutput>("%s", "lock acquired");
         return true;
@@ -791,14 +795,14 @@ private:
 #endif
     };
 
-    static std::mutex s_lock;
+    static std::timed_mutex s_lock;
     static LockedData* s_data;
 
 private:
     static std::atomic<bool> s_paused;
 };
 
-std::mutex HeapTrack::s_lock;
+std::timed_mutex HeapTrack::s_lock;
 HeapTrack::LockedData* HeapTrack::s_data {nullptr};
 std::atomic<bool> HeapTrack::s_paused {false};
 }

--- a/src/track/trace.h
+++ b/src/track/trace.h
@@ -71,8 +71,17 @@ struct Trace
 
     static void print();
 
+    /// limit the number of frames captured per backtrace, must be in [1, MAX_SIZE]
+    static void setMaxDepth(int depth)
+    {
+        assert(depth >= 1 && depth <= MAX_SIZE);
+        s_maxDepth = depth;
+    }
+
 private:
     static int unwind(void** data);
+
+    inline static int s_maxDepth = MAX_SIZE;
 
 private:
     int m_size = 0;

--- a/src/track/trace_libunwind.cpp
+++ b/src/track/trace_libunwind.cpp
@@ -64,5 +64,5 @@ void Trace::setup()
 
 int Trace::unwind(void** data)
 {
-    return unw_backtrace(data, MAX_SIZE);
+    return unw_backtrace(data, s_maxDepth);
 }

--- a/src/track/trace_unwind_tables.cpp
+++ b/src/track/trace_unwind_tables.cpp
@@ -54,7 +54,7 @@ int Trace::unwind(void** data)
 {
     backtrace trace;
     trace.data = data;
-    trace.max_size = MAX_SIZE;
+    trace.max_size = s_maxDepth;
 
     _Unwind_Backtrace(unwind_backtrace_callback, &trace);
     return trace.ctr;


### PR DESCRIPTION
Background - I run heaptrack on an embedded linux device that has a similar amount of horsepower to later Raspberry Pis. The application I'm working on is a Qt-QML application with custom 3d rendering and some pretty heavy data processing - you might imagine there's _quite_ a bit of heap allocation going on. After making these changes, I'm able to run the project without the whole thing grinding to an unusable halt.

Two changes here, one per commit
* Change the mutex lock wait strategy
  * Using the `futex` wait-for functionality instead of a try-lock, wait loop improves performance in heavily concurrent applications. PThreads is able to do a better job waking up threads quickly when we let it handle the try-then-wake loop like this; and the strategy that the kernel uses to schedule short sleeps can actually cause a "sleep 1 microsecond" to end up being closer to 50 us due to the timer coelescing behaviors, depending on your kernel settings and process priority.
* Add an option to limit stack depth
  * Running `perf` to record a trace of my process while it's being `heaptrack`ed shows that the stack unwind is the _most_ expensive part of the heaptrack overhead. I don't need a full 64 frames of the stack to figure out what's going on in most cases, and cutting it down to 32 or 16 improves performance massively.
